### PR TITLE
Update the IMI to use GEOS-Chem 14.0.0

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,10 +26,14 @@ NestedGrid: true
 
 ## Select nested grid region (for using pre-cropped meteorological fields)
 ##   Current options are listed below with ([lat],[lon]) bounds:
+##     "AF" : Africa ([-37,40], [-20,53])
 ##     "AS" : Asia ([-11,55],[60,150]) 
 ##     "EU" : Europe ([33,61],[-30,70])
+##     "ME" : Middle East ([12,44], [-20,70])
 ##     "NA" : North America ([10,70],[-140,-40])
-##     "SA" : South America ([-56,13], [-85,-33])
+##     "OC" : Oceania ([-50,5], [110,180])
+##     "RU" : Russia ([41,83], [19,180])
+##     "SA" : South America ([-59,16], [-88,-31])
 ##     ""   : Use for global met fields (global simulation/custom nested grids)
 ##   For example, if the region of interest is in Europe ([33,61],[-30,70]), select "EU".
 NestedRegion: "NA"

--- a/docs/source/advanced/custom-region.rst
+++ b/docs/source/advanced/custom-region.rst
@@ -3,9 +3,19 @@ Using custom regions with the IMI
 
 .. include:: <isonum.txt>
 
-The IMI version currently supports regions within North America (10\ |deg|\ N-70\ |deg|\ N, 40\ |deg|\ W-140\ |deg|\ W), Europe
-(33\ |deg|\ N-61\ |deg|\ N, 30\ |deg|\ W-70\ |deg|\ E), and Asia (11\ |deg|\ S-55\ |deg|\ N, 60\ |deg|\ E-150\ |deg|\ E).
-These are the default nested-grid windows used in GEOS-Chem for which pre-cut meteorological files are available. You may apply the
+The IMI supports regions within the following
+domains:
+
+* Africa: 37\ |deg|\ S-40\ |deg|\ N, 20\ |deg|\ W-53\ |deg|\ E
+* Asia: 11\ |deg|\ S-55\ |deg|\ N, 60\ |deg|\ E-150\ |deg|\ E
+* Europe: (33\ |deg|\ N-61\ |deg|\ N, 30\ |deg|\ W-70\ |deg|\ E
+* Middle East: 12\ |deg|\ N-44\ |deg|\ N, 20\ |deg|\ W-70\ |deg|\ E
+* North America: 10\ |deg|\ N-70\ |deg|\ N, 140\ |deg|\ W-40\ |deg|\ W
+* Oceania 50\ |deg|\ S-5\ |deg|\ N, 110\ |deg|\ E-180\ |deg|\ E
+* Russia 41\ |deg|\ N-83\ |deg|\ N, 19\ |deg|\ E-180\ |deg|\ E
+* South America 59\ |deg|\ S-16\ |deg|\ N, 88\ |deg|\ W-31\ |deg|\ W
+  
+These are the nested-grid windows used in GEOS-Chem for which pre-cut meteorological files are available. You may apply the
 IMI to other regions, but this requires either using global meteorological fields which can be 
 computationally expensive (not recommended) or cropping global meteorological fields via
 a pre-processing step.

--- a/docs/source/getting-started/imi-config-file.rst
+++ b/docs/source/getting-started/imi-config-file.rst
@@ -50,7 +50,7 @@ Region of interest
      - Boolean for using the GEOS-Chem nested grid simulation. Must be
        ``true`` for IMI regional inversions.
    * - ``NestedRegion``
-     - Nesting domain for the inversion. Select ``AS`` for Asia, ``EU`` for Europe, or ``NA`` for North America. For global met fields set this option to ``""`` See the `GEOS-Chem horizontal grids <http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_horizontal_grids>`_ documentation for details about the available nested-grid domains.
+     - Nesting domain for the inversion. Select ``AF`` for Africa, ``AS`` for Asia, ``EU`` for Europe, ``ME`` for the Middle East, ``NA`` for North America, ``OC`` for Oceania, ``RU`` for Russia, or ``SA`` for South America. For global met fields set this option to ``""`` See the `GEOS-Chem horizontal grids <http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_horizontal_grids>`_ documentation for details about the available nested-grid domains.
 
 State vector 
 ~~~~~~~~~~~~

--- a/envs/Harvard-Cannon/config.harvard-cannon.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.yml
@@ -17,10 +17,14 @@ NestedGrid: true
 
 ## Select nested grid region for using pre-cropped met fields
 ##   Current options are listed below with ([lat],[lon]) bounds:
+##    "AF" : Africa ([-37,40], [-20,53])
 ##    "AS" : Asia ([-11,55],[60,150]) 
 ##    "EU" : Europe ([33,61],[-30,70])
+##    "ME" : Middle East ([12,44], [-20,70])
 ##    "NA" : North America ([10,70],[-140,-40])
-##    "SA" : South America ([-56,13], [-85,-33])
+##    "OC" : Oceania ([-50,5], [110,180])
+##    "RU" : Russia ([41,83], [19,180])
+##    "SA" : South America ([-59,16], [-88,-31])
 ##    ""   : Use for global met fields (global simulation/custom nested grids)
 NestedRegion: "NA"
 

--- a/run_imi.sh
+++ b/run_imi.sh
@@ -98,7 +98,9 @@ if "$isAWS"; then
     printf "\nFinished TROPOMI download\n"
 else
     # use existing tropomi data and create a symlink to it
-    ln -s $DataPathTROPOMI $tropomiCache
+    if [[ ! -L $tropomiCache ]]; then
+	ln -s $DataPathTROPOMI $tropomiCache
+    fi
 fi
 
 ##=======================================================================

--- a/setup_imi.sh
+++ b/setup_imi.sh
@@ -197,8 +197,8 @@ LonMaxInvDomain=$(ncmax lon ${RunDirs}/StateVector.nc)
 LatMinInvDomain=$(ncmin lat ${RunDirs}/StateVector.nc)
 LatMaxInvDomain=$(ncmax lat ${RunDirs}/StateVector.nc)
 rm ~/foo.nc
-Lons="${LonMinInvDomain} ${LonMaxInvDomain}"
-Lats="${LatMinInvDomain} ${LatMaxInvDomain}"
+Lons="${LonMinInvDomain}, ${LonMaxInvDomain}"
+Lats="${LatMinInvDomain}, ${LatMaxInvDomain}"
 
 ##=======================================================================
 ## Set up template run directory
@@ -215,6 +215,7 @@ if "$SetupTemplateRundir"; then
 
     # The createRunDir.sh script assumes the file ~/.geoschem/config exists
     # and contains the path to GEOS-Chem input data
+	export GC_USER_REGISTERED=true
     if [[ ! -f ${HOME}/.geoschem/config ]]; then
 	mkdir -p ${HOME}/.geoschem
 	echo "export GC_DATA_ROOT=${DataPath}" >> ${HOME}/.geoschem/config
@@ -247,10 +248,10 @@ if "$SetupTemplateRundir"; then
     # Modify geoschem_config.yml based on settings in config.yml
     sed -i -e "s:20190101:${StartDate}:g" \
            -e "s:20190201:${EndDate}:g" \
-           -e "s:GEOSFP:${Met}:g" \
+           -e "s:geosfp:${Met}:g" \
            -e "s:0.25x0.3125:${gridResLong}:g" \
-           -e "s:-130.0  -60.0:${Lons}:g" \
-           -e "s:9.75  60.0:${Lats}:g" geoschem_config.yml
+           -e "s:-130.0,  -60.0:${Lons}:g" \
+           -e "s:9.75,  60.0:${Lats}:g" geoschem_config.yml
 
     # For CH4 inversions always turn analytical inversion on
     sed -i "/analytical_inversion/{N;s/activate: false/activate: true/}" geoschem_config.yml

--- a/setup_imi.sh
+++ b/setup_imi.sh
@@ -478,7 +478,7 @@ if  "$DoPreview"; then
         chmod +x $preview_file
         sbatch -W $preview_file $config_path $state_vector_path $preview_dir $tropomi_cache; wait;
     else
-        python $preview_file $config_path $state_vector_path $preview_dir $tropomi_cache
+        python $preview_file $InversionPath $config_path $state_vector_path $preview_dir $tropomi_cache
     fi
     printf "\n=== DONE RUNNING IMI PREVIEW ===\n"
 
@@ -606,7 +606,7 @@ if  "$SetupPosteriorRun"; then
     ln -s ${RunTemplate}/gcclassic .
 
     # Link to restart file
-    RestartFileFromSpinup=../spinup_run/Restarts/GEOSChem.Restart.${SpinupEnd}_0000z.nc4
+    RestartFileFromSpinup=../../spinup_run/Restarts/GEOSChem.Restart.${SpinupEnd}_0000z.nc4
     if test -f "$RestartFileFromSpinup" || "$DoSpinup"; then
         ln -s $RestartFileFromSpinup Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
     else

--- a/setup_imi.sh
+++ b/setup_imi.sh
@@ -728,7 +728,7 @@ if "$SetupJacobianRuns"; then
 	ln -s ${RunTemplate}/gcclassic .
 
     # Link to restart file
-    RestartFileFromSpinup=../../spinup_run/Restarts/GEOSChem.Restart.${SpinupEnd}_0000z.nc4
+    RestartFileFromSpinup=../../../spinup_run/Restarts/GEOSChem.Restart.${SpinupEnd}_0000z.nc4
     if test -f "$RestartFileFromSpinup" || "$DoSpinup"; then
         ln -s $RestartFileFromSpinup Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
 	else

--- a/setup_imi.sh
+++ b/setup_imi.sh
@@ -244,23 +244,16 @@ if "$SetupTemplateRundir"; then
 	sed -i "s/command: 'aws s3 cp --request-payer=requester '/command: 'aws s3 cp --request-payer=requester --only-show-errors '/" download_data.yml
     fi
 
-    # Modify input.geos based on settings in config.yml
+    # Modify geoschem_config.yml based on settings in config.yml
     sed -i -e "s:20190101:${StartDate}:g" \
            -e "s:20190201:${EndDate}:g" \
            -e "s:GEOSFP:${Met}:g" \
            -e "s:0.25x0.3125:${gridResLong}:g" \
            -e "s:-130.0  -60.0:${Lons}:g" \
-           -e "s:9.75  60.0:${Lats}:g" input.geos
-    if [ "$NestedGrid" == "false" ]; then
-	sed -i -e "Nested grid simulation? : T|Nested grid simulation? : F|g" \
-               -e "s|timestep \[sec\]: 600|timestep \[sec\]: 1200|g" \
-               -e "s|timestep \[sec\]: 300|timestep \[sec\]: 600|g" input.geos
-    fi
+           -e "s:9.75  60.0:${Lats}:g" geoschem_config.yml
 
     # For CH4 inversions always turn analytical inversion on
-    OLD="Do analytical inversion?: F"
-    NEW="Do analytical inversion?: T"
-    sed -i "s/$OLD/$NEW/g" input.geos
+    sed -i "/analytical_inversion/{N;s/activate: false/activate: true/}" geoschem_config.yml
 
     # Also turn on analytical inversion option in HEMCO_Config.rc
     OLD="--> AnalyticalInv          :       false"
@@ -274,41 +267,40 @@ if "$SetupTemplateRundir"; then
 
     # Turn other options on/off according to settings above
     if "$GOSAT"; then
-	OLD="Use GOSAT obs operator? : F"
-	NEW="Use GOSAT obs operator? : T"
-	sed -i "s/$OLD/$NEW/g" input.geos
+	OLD="GOSAT: false"
+	NEW="GOSAT: true"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
     fi
     if "$TCCON"; then
-	OLD="Use TCCON obs operator? : F"
-	NEW="Use TCCON obs operator? : T"
-	sed -i "s/$OLD/$NEW/g" input.geos
+	OLD="TCCON: false"
+	NEW="TCCON: true"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
     fi
     if "$AIRS"; then
-	OLD="Use AIRS obs operator?  : F"
-	NEW="Use AIRS obs operator?  : T"
-	sed -i "s/$OLD/$NEW/g" input.geos
+	OLD="AIR: false"
+	NEW="AIR: true"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
     fi
     if "$UseEmisSF"; then
-	OLD="Use emis scale factor   : F"
-	NEW="Use emis scale factor   : T"
-	sed -i "s/$OLD/$NEW/g" input.geos
+	OLD="use_emission_scale_factor: false"
+	NEW="use_emission_scale_factor: true"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
     fi
     if "$UseOHSF"; then
-	OLD="Use OH scale factors    : F"
-	NEW="Use OH scale factors    : T"
-	sed -i "s/$OLD/$NEW/g" input.geos
+	OLD="use_OH_scale_factors: false"
+	NEW="use_OH_scale_factors: true"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
     fi
     if "$PLANEFLIGHT"; then
 	mkdir -p Plane_Logs
-	OLD="Turn on plane flt diag? : F"
-	NEW="Turn on plane flt diag? : T"
-	sed -i "s/$OLD/$NEW/g" input.geos
-	OLD="Flight track info file  : Planeflight.dat.YYYYMMDD"
-	NEW="Flight track info file  : Planeflights\/Planeflight.dat.YYYYMMDD"
-	sed -i "s/$OLD/$NEW/g" input.geos
-	OLD="Output file name        : plane.log.YYYYMMDD"
-	NEW="Output file name        : Plane_Logs\/plane.log.YYYYMMDD"
-	sed -i "s/$OLD/$NEW/g" input.geos
+	sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
+	
+	OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
+	NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+	OLD="output_file: plane.log.YYYYMMDD"
+	NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
     fi
 
     # Modify HEMCO_Config.rc based on settings in config.yml
@@ -352,10 +344,7 @@ if "$SetupTemplateRundir"; then
     fi
 
     # Remove sample restart file
-    rm -f GEOSChem.Restart.20190101_0000z.nc4
-
-    # Create directory for restart files
-    mkdir -p Restarts
+    rm -f Restarts/GEOSChem.Restart.20190101_0000z.nc4
 
     # Copy template run script
     cp ${InversionPath}/src/geoschem_run_scripts/ch4_run.template .
@@ -396,7 +385,7 @@ if  "$DoPreview"; then
     fi
 
     # Make sure template run directory exists
-    if [[ ! -f ${RunTemplate}/input.geos ]]; then
+    if [[ ! -f ${RunTemplate}/geoschem_config.yml ]]; then
         printf "\nTemplate run directory does not exist or has missing files. Please set 'SetupTemplateRundir=true' in config.yml\n" 
         exit 9999
     fi
@@ -422,7 +411,7 @@ if  "$DoPreview"; then
 
     # Link to restart file
     RestartFilePreview=${RestartFilePreviewPrefix}${StartDate}_0000z.nc4
-    ln -s $RestartFilePreview GEOSChem.Restart.${StartDate}_0000z.nc4
+    ln -s $RestartFilePreview Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
     if "$UseBCsForRestart"; then
         sed -i -e "s|SpeciesRst|SpeciesBC|g" HEMCO_Config.rc
     fi
@@ -430,10 +419,9 @@ if  "$DoPreview"; then
     # End date for the preview simulation
     PreviewEnd=$(date --date="${StartDate} +1 day" +%Y%m%d)
 
-    # Update settings in input.geos
-    sed -i -e "s|${EndDate}|${PreviewEnd}|g" \
-           -e "s|Do analytical inversion?: T|Do analytical inversion?: F|g" \
-           input.geos
+    # Update settings in geoschem_config.yml
+    sed -i -e "s|${EndDate}|${PreviewEnd}|g" geoschem_config.yml
+    sed -i "/analytical_inversion/{N;s/activate: true/activate: false/}" geoschem_config.yml
 
     # Update settings in HEMCO_Config.rc
     sed -i -e "s|DiagnFreq:                   Monthly|DiagnFreq:                   End|g" HEMCO_Config.rc
@@ -514,7 +502,7 @@ preview_end=$(date +%s)
 if  "$SetupSpinupRun"; then
 
     # Make sure template run directory exists
-    if [[ ! -f ${RunTemplate}/input.geos ]]; then
+    if [[ ! -f ${RunTemplate}/geoschem_config.yml ]]; then
         printf "\nTemplate run directory does not exist or has missing files. Please set 'SetupTemplateRundir=true' in config.yml\n" 
         exit 9999
     fi
@@ -540,17 +528,16 @@ if  "$SetupSpinupRun"; then
 
     # Link to restart file
     RestartFile=${RestartFilePrefix}${SpinupStart}_0000z.nc4
-    ln -s $RestartFile GEOSChem.Restart.${SpinupStart}_0000z.nc4
+    ln -s $RestartFile Restarts/GEOSChem.Restart.${SpinupStart}_0000z.nc4
     if "$UseBCsForRestart"; then
         sed -i -e "s|SpeciesRst|SpeciesBC|g" HEMCO_Config.rc
 	printf "\nWARNING: Changing restart field entry in HEMCO_Config.rc to read the field from a boundary condition file. Please revert SpeciesBC_ back to SpeciesRst_ for subsequent runs.\n" 
     fi
     
-    # Update settings in input.geos
+    # Update settings in geoschem_config.yml
     sed -i -e "s|${StartDate}|${SpinupStart}|g" \
-           -e "s|${EndDate}|${SpinupEnd}|g" \
-           -e "s|Do analytical inversion?: T|Do analytical inversion?: F|g" \
-           input.geos
+           -e "s|${EndDate}|${SpinupEnd}|g" geoschem_config.yml
+    sed -i "/analytical_inversion/{N;s/activate: true/activate: false/}" geoschem_config.yml
 
     # Turn on LevelEdgeDiags output
     if "$HourlyCH4"; then
@@ -593,7 +580,7 @@ fi # SetupSpinupRun
 if  "$SetupPosteriorRun"; then
 
     # Make sure template run directory exists
-    if [[ ! -f ${RunTemplate}/input.geos ]]; then
+    if [[ ! -f ${RunTemplate}/geoschem_config.yml ]]; then
         printf "\nTemplate run directory does not exist or has missing files. Please set 'SetupTemplateRundir=true' in config.yml" 
         exit 9999
     fi
@@ -618,23 +605,22 @@ if  "$SetupPosteriorRun"; then
     ln -s ${RunTemplate}/gcclassic .
 
     # Link to restart file
-    RestartFileFromSpinup=../spinup_run/GEOSChem.Restart.${SpinupEnd}_0000z.nc4
+    RestartFileFromSpinup=../spinup_run/Restarts/GEOSChem.Restart.${SpinupEnd}_0000z.nc4
     if test -f "$RestartFileFromSpinup" || "$DoSpinup"; then
-        ln -s $RestartFileFromSpinup GEOSChem.Restart.${StartDate}_0000z.nc4
+        ln -s $RestartFileFromSpinup Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
     else
         RestartFile=${RestartFilePrefix}${StartDate}_0000z.nc4
-        ln -s $RestartFile GEOSChem.Restart.${StartDate}_0000z.nc4
+        ln -s $RestartFile Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
         if "$UseBCsForRestart"; then
             sed -i -e "s|SpeciesRst|SpeciesBC|g" HEMCO_Config.rc
             printf "\nWARNING: Changing restart field entry in HEMCO_Config.rc to read the field from a boundary condition file. Please revert SpeciesBC_ back to SpeciesRst_ for subsequent runs.\n" 
         fi
     fi
     
-    # Update settings in input.geos
-    sed -i -e "s|Do analytical inversion?: T|Do analytical inversion?: F|g" \
-           -e "s|Use emis scale factor   : F|Use emis scale factor   : T|g" \
-           input.geos
-
+    # Update settings in geoschem_config.yml
+    sed -i "/analytical_inversion/{N;s/activate: true/activate: false/}" geoschem_config.yml
+    sed -i "s/use_emission_scale_factor: false/use_emission_scale_factor: true/g" geoschem_config.yml
+    
     # Update settings in HEMCO_Config.rc
     sed -i -e "s|--> Emis_ScaleFactor       :       false|--> Emis_ScaleFactor       :       true|g" \
            -e "s|gridded_posterior.nc|${RunDirs}/inversion/gridded_posterior.nc|g" HEMCO_Config.rc
@@ -680,7 +666,7 @@ fi # SetupPosteriorRun
 if "$SetupJacobianRuns"; then
 
     # Make sure template run directory exists
-    if [[ ! -f ${RunTemplate}/input.geos ]]; then
+    if [[ ! -f ${RunTemplate}/geoschem_config.yml ]]; then
         printf "\nTemplate run directory does not exist or has missing files. Please set 'SetupTemplateRundir=true' in config.yml" 
         exit 9999
     fi
@@ -741,20 +727,20 @@ if "$SetupJacobianRuns"; then
 	ln -s ${RunTemplate}/gcclassic .
 
     # Link to restart file
-    RestartFileFromSpinup=../../spinup_run/GEOSChem.Restart.${SpinupEnd}_0000z.nc4
+    RestartFileFromSpinup=../../spinup_run/Restarts/GEOSChem.Restart.${SpinupEnd}_0000z.nc4
     if test -f "$RestartFileFromSpinup" || "$DoSpinup"; then
-        ln -s $RestartFileFromSpinup GEOSChem.Restart.${StartDate}_0000z.nc4
+        ln -s $RestartFileFromSpinup Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
 	else
 	    RestartFile=${RestartFilePrefix}${StartDate}_0000z.nc4
-	    ln -s $RestartFile GEOSChem.Restart.${StartDate}_0000z.nc4
+	    ln -s $RestartFile Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
 	    if "$UseBCsForRestart"; then
 		sed -i -e "s|SpeciesRst|SpeciesBC|g" HEMCO_Config.rc
             fi
 	fi
    
-	# Update settings in input.geos
-	sed -i -e "s|Emiss perturbation  : 1.0|Emiss perturbation  : ${PerturbValue}|g" \
-	       -e "s|State vector elem. #: 0|State vector elem. #: ${xUSE}|g" input.geos
+	# Update settings in geoschem_config.yml
+	sed -i -e "s|emission_perturbation: 1.0|emission_perturbation: ${PerturbValue}|g" \
+	       -e "s|state_vector_element_number: 0|state_vector_element_number: ${xUSE}|g" geoschem_config.yml
 
 	# Update settings in HISTORY.rc
 	# Only save out hourly pressure fields to daily files for base run

--- a/src/geoschem_run_scripts/ch4_run.template
+++ b/src/geoschem_run_scripts/ch4_run.template
@@ -3,7 +3,7 @@
 ##SBATCH -c 8
 ##SBATCH -N 1
 ##SBATCH -t 0-06:00
-##SBATCH --mem=6000
+##SBATCH --mem=32000
 ##SBATCH --mail-type=END
 
 # Set the proper # of threads for OpenMP

--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -75,7 +75,7 @@ def get_TROPOMI_data(file_path, xlim, ylim, startdate_np64, enddate_np64):
     return tropomi_data
 
 
-def imi_preview(config_path, state_vector_path, preview_dir, tropomi_cache):
+def imi_preview(inversion_path, config_path, state_vector_path, preview_dir, tropomi_cache):
     """
     Function to perform preview
     Requires preview simulation to have been run already (to generate HEMCO diags)
@@ -89,12 +89,12 @@ def imi_preview(config_path, state_vector_path, preview_dir, tropomi_cache):
     # Read config file
     config = yaml.load(open(config_path), Loader=yaml.FullLoader)
     # redirect output to log file
-    if config["isAWS"]:
-        output_file = open(
-            "/home/ubuntu/integrated_methane_inversion/imi_output.log", "a"
-        )
-        sys.stdout = output_file
-        sys.stderr = output_file
+    output_file = open(
+        f"{inversion_path}/imi_output.log", "a"
+    )
+    sys.stdout = output_file
+    sys.stderr = output_file
+    
     # Open the state vector file
     state_vector = xr.load_dataset(state_vector_path)
     state_vector_labels = state_vector["StateVector"]

--- a/src/utilities/crop_met.sh
+++ b/src/utilities/crop_met.sh
@@ -7,10 +7,10 @@
 
 ##############################################################################
 # Custom to Harvard FAS RC cluster:
-#SBATCH -n 4
+#SBATCH -n 1
 #SBATCH -N 1
-#SBATCH -t 0-12:00
-#SBATCH -p huce_intel
+#SBATCH -t 0-6:00
+#SBATCH -p huce_cascade
 #SBATCH --mem=2000
 #SBATCH --mail-type=END
 
@@ -27,10 +27,10 @@ module load cdo/1.9.4-fasrc02
 NestedRegion="SA"  # South America
 
 # Bounds of the cropped domain
-LonMin=-85.0
-LonMax=-33.0
-LatMin=-56.0
-LatMax=13.0
+LonMin=-88.0
+LonMax=-31.0
+LatMin=-59.0
+LatMax=16.0
 
 # Directory containing global met fields
 DownloadGlobalMet=true
@@ -80,11 +80,13 @@ for (( Month=$StartMonth; Month<=$EndMonth; Month++)); do
         mm="${Month}"
     fi
     
+    printf "Processing month $mm\n"
+
     # Download global meteorology fields for this month
     if "$DownloadGlobalMet"; then
-	printf "Downloading global meteorology files for ${Year}/${mm}"
+	printf "Downloading global meteorology files for ${Year}/${mm}\n"
 	wget -r -nH --cut-dirs=3 -e robots=off -nv -o "download_met.log" -P "${GlobalDir}" -A "*.nc" "http://geoschemdata.wustl.edu/ExtData/GEOS_0.25x0.3125/GEOS_FP/${Year}/${mm}/"
-	echo "Done downloading global meteorology files"
+	printf "Done downloading global meteorology files\n"
     fi
     # Path to global files
     InPath="${GlobalDir}/${Year}/${mm}"


### PR DESCRIPTION
This PR includes the following updates:

- Modify `setup_imi.sh` for GEOS-Chem 14.0.0. This includes replacing references to input.geos with geoschem_config.yml and changing restart file paths.
- Update configuration file and documentation to reflect new supported regional domains.
- Add minor fix to `run_imi.sh` to avoid creating a symbolic link to the TROPOMI data if it already exists.
- Increase memory requested in run script so that a simulation for the example region won't crash.