### PR TITLE
bug fix to make jacobian.py save viz output data

### DIFF
--- a/src/inversion_scripts/jacobian.py
+++ b/src/inversion_scripts/jacobian.py
@@ -163,6 +163,6 @@ if __name__ == "__main__":
         if output["obs_GC"].shape[0] > 0:
             print("Saving .pkl file")
             save_obj(output, f"{outputdir}/{date}_GCtoTROPOMI.pkl")
-            save_obj(output, f"{vizdir}/{date}_GCtoTROPOMI.pkl")
+            save_obj(viz_output, f"{vizdir}/{date}_GCtoTROPOMI.pkl")
 
     print(f"Wrote files to {outputdir}")


### PR DESCRIPTION
`jacobian.py` should apply both the super-observation TROPOMI operator and the single-observation TROPOMI operator, and save out both results (former for use in the inversion, latter for use in visualization). Currently the viz data isn't being saved. This PR addresses that bug.