### PR TITLE
Feature/generate cluster pairs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -46,9 +46,7 @@ LandThreshold: 0.25
 
 ## Clustering Options
 ReducedDimensionStateVector: false
-ClusteringPairs:
-  - [1, 15]
-  - [2, 24]
+NumberOfElements: 45
 ForcedNativeResolutionElements: 
   - [31.5, -104]
   

--- a/envs/Harvard-Cannon/config.harvard-cannon.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.yml
@@ -44,9 +44,7 @@ LandThreshold: 0.25
 
 ## Clustering Options
 ReducedDimensionStateVector: false
-ClusteringPairs:
-  - [1, 15]
-  - [2, 24]
+NumberOfElements: 45
 ForcedNativeResolutionElements: 
   - [31.5, -104]
 

--- a/src/components/statevector_component/aggregation.py
+++ b/src/components/statevector_component/aggregation.py
@@ -337,12 +337,27 @@ def generate_cluster_pairs(sensitivities, desired_element_num, num_buffer_elemen
             + "Remember to take into account the number of buffer elements."
         )
 
-    sensitivities.sort(reverse=True)
+    # sort sensitivities in ascending order
+    sensitivities = np.sort(sensitivities)[::-1]
+
+
+    # determine dofs threshold for each cluster and create optimal pairings
     target_dofs_per_cluster = sum(sensitivities) / desired_element_num
-    pairs = find_cluster_pairs(
+    cluster_pairs = find_cluster_pairs(
         sensitivities, target_dofs_per_cluster, desired_element_num
     )
-    return list(pairs.items())
+
+    # put cluster pairs into format expected by clustering algorithm
+    cluster_pairs = list(cluster_pairs.items())
+    print(f"Generated cluster pairings: {cluster_pairs}")
+    new_cluster_pairs = []
+
+    for cells_per_cluster, num_clusters in cluster_pairs:
+        native_cells = num_clusters * cells_per_cluster
+        new_cluster_pairs.append((cells_per_cluster, native_cells))
+
+    # sort cluster pairs in ascending order
+    return sorted(new_cluster_pairs, key=lambda x: x[0])
 
 
 def force_native_res_pixels(config, clusters, sensitivities):


### PR DESCRIPTION
This PR automatically generates the clustering pairs using the following algorithm:
1. find the average sensitivity/ statevector element using the total estimated dofs/ desired number of elements. this is the threshold used for each element.
2. sort the estimated sensitivities in descending order
3. group the largest sensitivities until adding the next element would exceed the threshold. This is a cluster pair.
4. remove the selected elements from the sensitivity list
5. iterate through 3 and 4 until no elements are left
This is the basic idea but it also covers some basic edge cases like:
- If the sensitivity of a single element is greater than the threshold, then the element is added at native resolution.
- If the algorithm produces too few elements it simply adds additional native resolution elements. 
- If the algorithm is about to exceed the number of elements, then all remaining elements are aggregated into a single element.

Still need to update the documentation. New clustering section for config.yml is:
```
# Clustering options
ReducedDimensionStateVector: true
NumberOfElements: 45
ForcedNativeResolutionElements: 
  - [31.5, -104]
```

