### PR TITLE
Make sure there are not duplicate TROPOMI files

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -122,6 +122,9 @@ else
     fi
 fi
 
+# Check to make sure there are no duplicate TROPOMI files (e.g., two files with the same orbit number but a different processor version)
+python src/utilities/test_TROPOMI_dir.py $tropomiCache
+
 ##=======================================================================
 ##  Run the setup script
 ##=======================================================================

--- a/src/utilities/test_TROPOMI_dir.py
+++ b/src/utilities/test_TROPOMI_dir.py
@@ -1,0 +1,27 @@
+import re
+import glob
+import sys
+
+def check_for_duplicate_orbit_numbers(Sat_datadir):
+
+    """
+    Function that checks for duplicate TROPOMI filenames in your directory (either on your cluster or after download to AWS)
+    Takes advatnage of the fact that there should be the same number of unique orbit numbers as there are files
+    """
+    
+    files = sorted(glob.glob(Sat_datadir + "/*.nc"))
+
+    all_orbit_numbers = []
+    for filename in files:
+        matches = re.findall(r'_(\d{5})_', filename) # find orbit number
+        assert len(matches) == 1, f"Please check the TROPOMI filenames, as they are not formatted in the way that the IMI expects. (e.g., {filename})"
+        all_orbit_numbers.append(matches[0])
+        
+    number_of_unique_orbit_numbers = len(set(all_orbit_numbers)) # forming a set drops the duplicates
+    number_of_files_in_Sat_datadir = len(files)
+
+    assert number_of_unique_orbit_numbers == number_of_files_in_Sat_datadir, "There are duplicate TROPOMI datafiles (as defined by their orbit number)."
+
+if __name__ == "__main__":
+    Sat_datadir = sys.argv[1]
+    check_for_duplicate_orbit_numbers(Sat_datadir)

--- a/src/utilities/test_TROPOMI_dir.py
+++ b/src/utilities/test_TROPOMI_dir.py
@@ -20,7 +20,7 @@ def check_for_duplicate_orbit_numbers(Sat_datadir):
     number_of_unique_orbit_numbers = len(set(all_orbit_numbers)) # forming a set drops the duplicates
     number_of_files_in_Sat_datadir = len(files)
 
-    assert number_of_unique_orbit_numbers == number_of_files_in_Sat_datadir, "There are duplicate TROPOMI datafiles (as defined by their orbit number)."
+    assert number_of_unique_orbit_numbers == number_of_files_in_Sat_datadir, "Duplicate orbit numbers found in TROPOMI datafiles. Remove duplicate files from system before continuing."
 
 if __name__ == "__main__":
     Sat_datadir = sys.argv[1]


### PR DESCRIPTION
We had an issue in the past where `download_TROPOMI.py` would result in users having duplicate TROPOMI files (e.g., two files with orbit number xxxxx, but one with processor version 02.04.00 and one with processor version 01.03.00). This simple  and fast test should prevent this in the future as processor version numbers continue to change.