### PR TITLE
bugfix to catch errors in TROPOMI variables

### DIFF
--- a/src/inversion_scripts/operators/TROPOMI_operator.py
+++ b/src/inversion_scripts/operators/TROPOMI_operator.py
@@ -455,87 +455,88 @@ def read_tropomi(filename):
     # Initialize dictionary for TROPOMI data
     dat = {}
 
-    # Store methane, QA, lat, lon
+    # Catch read errors in any of the variables
     try:
+        # Store methane, QA, lat, lon
         tropomi_data = xr.open_dataset(filename, group="PRODUCT")
+        dat["methane"] = tropomi_data["methane_mixing_ratio_bias_corrected"].values[0, :, :]
+        dat["qa_value"] = tropomi_data["qa_value"].values[0, :, :]
+        dat["longitude"] = tropomi_data["longitude"].values[0, :, :]
+        dat["latitude"] = tropomi_data["latitude"].values[0, :, :]
+
+        # Store UTC time
+        reference_time = tropomi_data["time"].values
+        delta_time = tropomi_data["delta_time"][0].values
+        strdate = []
+        if delta_time.dtype == "<m8[ns]":
+            strdate = reference_time + delta_time
+        elif delta_time.dtype == "<M8[ns]":
+            strdate = delta_time
+        else:
+            print(delta_time.dtype)
+            pass
+        dat["utctime"] = strdate
+
+        # Store time for whole orbit
+        times = np.zeros(shape=dat["longitude"].shape, dtype="datetime64[ns]")
+        for k in range(dat["longitude"].shape[0]):
+            times[k, :] = strdate[k]
+        dat["time"] = times
+        tropomi_data.close()
+
+        # Store column averaging kernel, SWIR and NIR surface albedo
+        tropomi_data = xr.open_dataset(
+            filename, group="PRODUCT/SUPPORT_DATA/DETAILED_RESULTS"
+        )
+        dat["column_AK"] = tropomi_data["column_averaging_kernel"].values[0, :, :, ::-1]
+        dat["swir_albedo"] = tropomi_data["surface_albedo_SWIR"].values[0, :, :]
+        dat["nir_albedo"] = tropomi_data["surface_albedo_NIR"].values[0, :, :]
+        dat["blended_albedo"] = 2.4 * dat["nir_albedo"] - 1.13 * dat["swir_albedo"]
+        tropomi_data.close()
+
+        # Store methane prior profile, dry air subcolumns
+        tropomi_data = xr.open_dataset(filename, group="PRODUCT/SUPPORT_DATA/INPUT_DATA")
+        dat["methane_profile_apriori"] = tropomi_data["methane_profile_apriori"].values[
+            0, :, :, ::-1
+        ]  # mol m-2
+        dat["dry_air_subcolumns"] = tropomi_data["dry_air_subcolumns"].values[
+            0, :, :, ::-1
+        ]  # mol m-2
+
+        # Also get pressure interval and surface pressure for use below
+        pressure_interval = (
+            tropomi_data["pressure_interval"].values[0, :, :] / 100
+        )  # Pa -> hPa
+        surface_pressure = (
+            tropomi_data["surface_pressure"].values[0, :, :] / 100
+        )  # Pa -> hPa
+        tropomi_data.close()
+
+        # Store latitude and longitude bounds for pixels
+        tropomi_data = xr.open_dataset(filename, group="PRODUCT/SUPPORT_DATA/GEOLOCATIONS")
+        dat["longitude_bounds"] = tropomi_data["longitude_bounds"].values[0, :, :, :]
+        dat["latitude_bounds"] = tropomi_data["latitude_bounds"].values[0, :, :, :]
+        tropomi_data.close()
+
+        # Store vertical pressure profile
+        n1 = dat["methane"].shape[
+            0
+        ]  # length of along-track dimension (scanline) of retrieval field
+        n2 = dat["methane"].shape[
+            1
+        ]  # length of across-track dimension (ground_pixel) of retrieval field
+        pressures = np.zeros([n1, n2, 12 + 1], dtype=np.float32)
+        pressures.fill(np.nan)
+        for i in range(12 + 1):
+            pressures[:, :, i] = surface_pressure - i * pressure_interval
+        dat["pressures"] = pressures
+
+    # Return an error if any of the variables were not read correctly
     except Exception as e:
-        print(f"Error opening {filename}: {e}")
-        return None
-
-    dat["methane"] = tropomi_data["methane_mixing_ratio_bias_corrected"].values[0, :, :]
-    dat["qa_value"] = tropomi_data["qa_value"].values[0, :, :]
-    dat["longitude"] = tropomi_data["longitude"].values[0, :, :]
-    dat["latitude"] = tropomi_data["latitude"].values[0, :, :]
-
-    # Store UTC time
-    reference_time = tropomi_data["time"].values
-    delta_time = tropomi_data["delta_time"][0].values
-    strdate = []
-    if delta_time.dtype == "<m8[ns]":
-        strdate = reference_time + delta_time
-    elif delta_time.dtype == "<M8[ns]":
-        strdate = delta_time
-    else:
-        print(delta_time.dtype)
-        pass
-    dat["utctime"] = strdate
-
-    # Store time for whole orbit
-    times = np.zeros(shape=dat["longitude"].shape, dtype="datetime64[ns]")
-    for k in range(dat["longitude"].shape[0]):
-        times[k, :] = strdate[k]
-    dat["time"] = times
-    tropomi_data.close()
-
-    # Store column averaging kernel, SWIR and NIR surface albedo
-    tropomi_data = xr.open_dataset(
-        filename, group="PRODUCT/SUPPORT_DATA/DETAILED_RESULTS"
-    )
-    dat["column_AK"] = tropomi_data["column_averaging_kernel"].values[0, :, :, ::-1]
-    dat["swir_albedo"] = tropomi_data["surface_albedo_SWIR"].values[0, :, :]
-    dat["nir_albedo"] = tropomi_data["surface_albedo_NIR"].values[0, :, :]
-    dat["blended_albedo"] = 2.4 * dat["nir_albedo"] - 1.13 * dat["swir_albedo"]
-    tropomi_data.close()
-
-    # Store methane prior profile, dry air subcolumns
-    tropomi_data = xr.open_dataset(filename, group="PRODUCT/SUPPORT_DATA/INPUT_DATA")
-    dat["methane_profile_apriori"] = tropomi_data["methane_profile_apriori"].values[
-        0, :, :, ::-1
-    ]  # mol m-2
-    dat["dry_air_subcolumns"] = tropomi_data["dry_air_subcolumns"].values[
-        0, :, :, ::-1
-    ]  # mol m-2
-
-    # Also get pressure interval and surface pressure for use below
-    pressure_interval = (
-        tropomi_data["pressure_interval"].values[0, :, :] / 100
-    )  # Pa -> hPa
-    surface_pressure = (
-        tropomi_data["surface_pressure"].values[0, :, :] / 100
-    )  # Pa -> hPa
-    tropomi_data.close()
-
-    # Store latitude and longitude bounds for pixels
-    tropomi_data = xr.open_dataset(filename, group="PRODUCT/SUPPORT_DATA/GEOLOCATIONS")
-    dat["longitude_bounds"] = tropomi_data["longitude_bounds"].values[0, :, :, :]
-    dat["latitude_bounds"] = tropomi_data["latitude_bounds"].values[0, :, :, :]
-    tropomi_data.close()
-
-    # Store vertical pressure profile
-    n1 = dat["methane"].shape[
-        0
-    ]  # length of along-track dimension (scanline) of retrieval field
-    n2 = dat["methane"].shape[
-        1
-    ]  # length of across-track dimension (ground_pixel) of retrieval field
-    pressures = np.zeros([n1, n2, 12 + 1], dtype=np.float32)
-    pressures.fill(np.nan)
-    for i in range(12 + 1):
-        pressures[:, :, i] = surface_pressure - i * pressure_interval
-    dat["pressures"] = pressures
+    print(f"Error opening {filename}: {e}")
+    return None
 
     return dat
-
 
 def average_tropomi_observations(TROPOMI, gc_lat_lon, sat_ind):
     """


### PR DESCRIPTION
### Name and Institution (Required)

Name: Sabour Baray
Institution: Environment and Climate Change Canada

### Describe the update

In the recently updated RPRO dataset, there appear to be some edge cases where an orbit file can be opened correctly, but still return a hdf5 error when trying to read a variable later on. This can interrupt the process of reading all TROPOMI files for a given time period.

I've shared another [script](https://github.com/sabourbaray/download_copernicus_py) that validates our local TROPOMI cache with the Copernicus repository by comparing exact filesizes, so I've double checked the files in our download process. It may be the case that these are files that could be problematic for any user.

Moving the error-catch to include all variables fixes this problem for me.