### PR TITLE
bugfix to only turn on extra observation switches for prior and posterior runs

### DIFF
--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -116,15 +116,15 @@ setup_jacobian() {
 		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
 	fi
 	if "$PLANEFLIGHT"; then
-	mkdir -p Plane_Logs
-	sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
+		mkdir -p Plane_Logs
+		sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
 	
-	OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
-	NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-	OLD="output_file: plane.log.YYYYMMDD"
-	NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+		OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
+		NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
+		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+		OLD="output_file: plane.log.YYYYMMDD"
+		NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
+		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
     	fi
     fi
 

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -100,32 +100,7 @@ setup_jacobian() {
 
     ### Turn on observation operators if requested, only for base run
     if [ $x -eq 0 ]; then
-    	if "$GOSAT"; then
-		OLD="GOSAT: false"
-		NEW="GOSAT: true"
-		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    	fi
-    	if "$TCCON"; then
-		OLD="TCCON: false"
-		NEW="TCCON: true"
-		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    	fi
-    	if "$AIRS"; then
-		OLD="AIR: false"
-		NEW="AIR: true"
-		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-	fi
-	if "$PLANEFLIGHT"; then
-		mkdir -p Plane_Logs
-		sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
-	
-		OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
-		NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
-		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-		OLD="output_file: plane.log.YYYYMMDD"
-		NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
-		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    	fi
+    	activate_observations
     fi
 
     ### Perform dry run if requested, only for base run

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -98,6 +98,36 @@ setup_jacobian() {
 	rm -f ch4_run.template
 	chmod 755 ${name}.run
 
+    ### Turn on observation operators if requested, only for base run
+    if [ $x -eq 0 ]; then
+    	if "$GOSAT"; then
+		OLD="GOSAT: false"
+		NEW="GOSAT: true"
+		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    	fi
+    	if "$TCCON"; then
+		OLD="TCCON: false"
+		NEW="TCCON: true"
+		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    	fi
+    	if "$AIRS"; then
+		OLD="AIR: false"
+		NEW="AIR: true"
+		sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+	fi
+	if "$PLANEFLIGHT"; then
+	mkdir -p Plane_Logs
+	sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
+	
+	OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
+	NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+	OLD="output_file: plane.log.YYYYMMDD"
+	NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    	fi
+    fi
+
     ### Perform dry run if requested, only for base run
     if [ $x -eq 0 ]; then
         if "$ProductionDryRun"; then

--- a/src/components/posterior_component/posterior.sh
+++ b/src/components/posterior_component/posterior.sh
@@ -62,6 +62,34 @@ setup_posterior() {
                -e 's/LevelEdgeDiags.mode:        '\''time-averaged/LevelEdgeDiags.mode:        '\''instantaneous/g' HISTORY.rc
     fi
 
+    ### Turn on observation operators if requested, for posterior run
+    if "$GOSAT"; then
+        OLD="GOSAT: false"
+        NEW="GOSAT: true"
+        sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    fi
+    if "$TCCON"; then
+        OLD="TCCON: false"
+        NEW="TCCON: true"
+        sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    fi
+    if "$AIRS"; then
+        OLD="AIR: false"
+        NEW="AIR: true"
+        sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    fi
+    if "$PLANEFLIGHT"; then
+	mkdir -p Plane_Logs
+	sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
+	
+	OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
+	NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+	OLD="output_file: plane.log.YYYYMMDD"
+	NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
+	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    fi
+
     # Create run script from template
     sed -e "s:namename:${PosteriorName}:g" \
 	-e "s:##:#:g" ch4_run.template > ${PosteriorName}.run

--- a/src/components/posterior_component/posterior.sh
+++ b/src/components/posterior_component/posterior.sh
@@ -63,32 +63,7 @@ setup_posterior() {
     fi
 
     ### Turn on observation operators if requested, for posterior run
-    if "$GOSAT"; then
-        OLD="GOSAT: false"
-        NEW="GOSAT: true"
-        sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    fi
-    if "$TCCON"; then
-        OLD="TCCON: false"
-        NEW="TCCON: true"
-        sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    fi
-    if "$AIRS"; then
-        OLD="AIR: false"
-        NEW="AIR: true"
-        sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    fi
-    if "$PLANEFLIGHT"; then
-	mkdir -p Plane_Logs
-	sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
-	
-	OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
-	NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-	OLD="output_file: plane.log.YYYYMMDD"
-	NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    fi
+    activate_observations
 
     # Create run script from template
     sed -e "s:namename:${PosteriorName}:g" \

--- a/src/components/setup_component/setup.sh
+++ b/src/components/setup_component/setup.sh
@@ -2,6 +2,7 @@
 
 # Functions available in this file include:
 #   - setup_imi
+#   - activate_observations
 
 # Description:
 #   This script will set up an Integrated Methane Inversion (IMI) with GEOS-Chem.
@@ -228,3 +229,38 @@ setup_imi() {
     echo "Note: this is part of the Setup runtime reported by run_imi.sh"
     printf "\n=== DONE RUNNING SETUP SCRIPT ===\n"
 }
+
+# Description: Turn on switches for extra observation operators
+#   Works on geoschem_config.yml file in the current directory  
+# Usage:
+#   activate_observations
+activate_observations() {
+    if "$GOSAT"; then
+            OLD="GOSAT: false"
+            NEW="GOSAT: true"
+            sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    fi
+    if "$TCCON"; then
+            OLD="TCCON: false"
+            NEW="TCCON: true"
+            sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    fi
+    if "$AIRS"; then
+            OLD="AIR: false"
+            NEW="AIR: true"
+            sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    fi
+    if "$PLANEFLIGHT"; then
+            mkdir -p Plane_Logs
+            sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
+
+            OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
+            NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
+            sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+            OLD="output_file: plane.log.YYYYMMDD"
+            NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
+            sed -i "s/$OLD/$NEW/g" geoschem_config.yml
+    fi
+
+}
+

--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -65,21 +65,6 @@ setup_template() {
     sed -i -e "s@$OLD@$NEW@g" HEMCO_Config.rc
 
     # Turn other options on/off according to settings above
-    if "$GOSAT"; then
-	OLD="GOSAT: false"
-	NEW="GOSAT: true"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    fi
-    if "$TCCON"; then
-	OLD="TCCON: false"
-	NEW="TCCON: true"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    fi
-    if "$AIRS"; then
-	OLD="AIR: false"
-	NEW="AIR: true"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    fi
     if "$UseEmisSF"; then
 	OLD="use_emission_scale_factor: false"
 	NEW="use_emission_scale_factor: true"
@@ -88,17 +73,6 @@ setup_template() {
     if "$UseOHSF"; then
 	OLD="use_OH_scale_factors: false"
 	NEW="use_OH_scale_factors: true"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-    fi
-    if "$PLANEFLIGHT"; then
-	mkdir -p Plane_Logs
-	sed -i "/planeflight/{N;s/activate: false/activate: true/}" geoschem_config.yml
-	
-	OLD="flight_track_file: Planeflight.dat.YYYYMMDD"
-	NEW="flight_track_file: Planeflights\/Planeflight.dat.YYYYMMDD"
-	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
-	OLD="output_file: plane.log.YYYYMMDD"
-	NEW="output_file: Plane_Logs\/plane.log.YYYYMMDD"
 	sed -i "s/$OLD/$NEW/g" geoschem_config.yml
     fi
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Sabour Baray
Institution: Environment and Climate Change Canada

### Describe the update

For the extra observation operators (GOSAT, TCCON, AIRS, Planeflight), currently the IMI switches them on in the template run, which is used to update the geoschem_config.yml files in all run directories. Users will likely only use these comparisons for the base run and posterior run, so we can save computational cost by not running these operators for each jacobian run.