### PR TITLE
Bugfix: Fix DOFS calculation

### DIFF
--- a/src/notebooks/visualization_notebook.ipynb
+++ b/src/notebooks/visualization_notebook.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8,6 +9,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -49,6 +51,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -120,6 +123,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -141,6 +145,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -219,6 +224,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -242,6 +248,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -281,11 +288,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DOFS = np.nansum(avkern_ROI.values)\n",
+    "# ungridded inversion result is used to calculate DOFS using the trace of the averaging kernel\n",
+    "A_ROI = xr.load_dataset(inversion_result_path)['A'].values[:last_ROI_element, :last_ROI_element]\n",
+    "DOFS = np.trace(A_ROI)\n",
     "print('DOFS =', DOFS)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -356,6 +366,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -376,6 +387,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -392,6 +404,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -399,6 +412,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -497,6 +511,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -613,6 +628,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
We noticed a bug in the visualization notebook DOFS calculation. This only occurs when using clustering. In `make_gridded_posterior.py` we map the calculated sensitivity values to the corresponding state vector elements. Eg. if element 3 has a sensitivity of .5, and is composed of 10 grid cells, then all 10 grid cells are set to .5. However, in `visualization_notebook.ipynb` the way we calculate DOFS is `np.nansum(avkern_ROI.values)` which sums every .25 degree grid cell. Per the example, we are effectively overcounting the sensitivity of element 3 by 10x. 

To fix this we simply use the un-gridded inversion result from `inversion_result.nc` to calculate DOFS.

Credit to Alex Oort Alonso for flagging this bug!

Confirmed that this fix works in the Permian test case (with no clustering).