### PR TITLE
Fix bugs in make_state_vector.py

### DIFF
--- a/src/notebooks/statevector_from_shapefile.ipynb
+++ b/src/notebooks/statevector_from_shapefile.ipynb
@@ -44,7 +44,8 @@
     "import matplotlib.pyplot as plt\n",
     "import yaml\n",
     "import warnings; warnings.filterwarnings(action='ignore')\n",
-    "sys.path.append('/home/ubuntu/integrated_methane_inversion/')\n",
+    "sys.path.append('../../')\n",
+    "from src.utilities.make_state_vector_file import cluster_buffer_elements\n",
     "from src.utilities.utils import download_landcover_files\n",
     "%matplotlib inline"
    ]
@@ -449,29 +450,8 @@
     }
    ],
    "source": [
-    "# Add buffer elements\n",
-    "buffer_elements = np.abs((mask > 0) - 1).values\n",
-    "\n",
-    "# Get image coordinates of buffer elements\n",
-    "irows = np.arange(buffer_elements.shape[0])\n",
-    "icols = np.arange(buffer_elements.shape[1])\n",
-    "irows = np.transpose(np.tile(irows,(len(icols),1)))\n",
-    "icols = np.tile(icols,(len(irows),1)) * (buffer_elements > 0)\n",
-    "\n",
-    "# Select image coordinates of buffer elements\n",
-    "irows_buffer = irows[buffer_elements > 0]\n",
-    "icols_buffer = icols[buffer_elements > 0]\n",
-    "coords = [[icols_buffer[j], irows_buffer[j]] for j in range(len(irows_buffer))]\n",
-    "\n",
-    "# Kmeans based on image coordinates\n",
-    "X = np.array(coords)\n",
-    "kmeans = KMeans(n_clusters=config['nBufferClusters'], random_state=0).fit(X)\n",
-    "\n",
-    "# Assign labels\n",
-    "for r in range(n_lat):\n",
-    "    for c in range(n_lon):\n",
-    "        if state_vector[r,c].values == 0:\n",
-    "            state_vector[r,c] = kmeans.predict([[c,r]])[0] + count\n",
+    "# cluster the buffer elements with the above function\n",
+    "state_vector = cluster_buffer_elements(state_vector, config['nBufferClusters'], state_vector.max().item())\n",
     "\n",
     "# Add units attribute\n",
     "state_vector.attrs['units'] = 'none'\n",
@@ -995,7 +975,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/src/utilities/make_state_vector_file.py
+++ b/src/utilities/make_state_vector_file.py
@@ -131,8 +131,12 @@ def make_state_vector_file(
     hd = xr.load_dataset(hemco_diag_pth)
 
     # Require hemco diags on same global grid as land cover map
-    if np.abs(lc.lon.values - hd.lon.values).max() != 0:
-        hd["lon"] = hd["lon"] - 0.03125  # initially offset by 0.03125 degrees
+    # TODO remove this offset once the HEMCO standalone files 
+    # are regenerated with recent bugfix that corrects the offset
+    if config["Res"] == "0.25x0.3125":
+             hd["lon"] = hd["lon"] - 0.03125
+    elif config["Res"] == "0.5x0.625":
+             hd["lon"] = hd["lon"] - 0.0625
 
     # Select / group fields together
     lc = (lc["FRLAKE"] + lc["FRLAND"] + lc["FRLANDIC"]).drop("time").squeeze()


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update

This PR addresses the following bugs in make_state_vector.py:

- an offset was mistakenly being applied in non 0.25 degree resolution grids
- faulty if statement caused land threshold to always evaluated to false
- In some cases labels would not be applied to buffer cells, causing gaps in the statevector labels resulting in perturbation simulations that would not be perturbed at all. This seems to only occur when using custom state vectors from a shapefile

To fix the 3rd bug I updated the buffer cell creation code and aligned them in `src/utilities/make_state_vector_file.py` and `src/notebooks/statevector_from_shapefile.ipynb`

@eastjames, tagging you and issue #181