### PR TITLE
Add stale Github action to automatically tag and close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'stale'
         exempt-issue-labels: 'never stale'
-        days-before-issue-stale: 60
+        days-before-issue-stale: 180
         days-before-issue-close: 7
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. If there are no updates within 7 days it will be closed. You can add the "never stale" tag to prevent the issue from closing this issue.'
         close-issue-message: 'Closing due to inactivity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+# This workflow warns and then closes issues that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues
+
+on:
+  schedule:
+  - cron: '0 0 * * *' # Run every night at midnight
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'never stale'
+        days-before-issue-stale: 60
+        days-before-issue-close: 7
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. If there are no updates within 7 days it will be closed. You can add the "never stale" tag to prevent the issue from closing this issue.'
+        close-issue-message: 'Closing due to inactivity'
+        days-before-pr-stale: -1
+        days-before-pr-close: -1


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The stale Github action is activated her. Issues with no activity in 60 days will be tagged as stale and if no action is taken they will be closed 7 days later. See https://github.com/actions/stale for more information on this Github action.

Note: For this action to take effect, it must be in the `main` branch. If preferred, I can change the base branch of this pull request to `dev` if we're willing to wait until the IMI 2.0 release for this action to start.
