### PR TITLE
Bug fix for environment file activations

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -65,6 +65,12 @@ if ! "$isAWS"; then
 	printf "\nLoading GEOS-Chem environment: ${GEOSChemEnv}\n"
         source ${GEOSChemEnv}
     fi
+else
+    # Source Conda environment file
+    source $CondaFile
+
+    # Activate Conda environment
+    conda activate ${CondaEnv}
 fi
 
 # Check all necessary config variables are present

--- a/src/components/inversion_component/inversion.sh
+++ b/src/components/inversion_component/inversion.sh
@@ -67,12 +67,6 @@ run_inversion() {
         cd ${RunDirs}/inversion
     fi
 
-    if ! "$isAWS"; then
-        # Activate Conda environment
-        printf "\nActivating conda environment: ${CondaEnv}\n"
-        conda activate $CondaEnv
-    fi
-
     # Execute inversion driver script
     sbatch --mem $SimulationMemory \
            -c $SimulationCPUs \

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -186,11 +186,6 @@ run_jacobian() {
 
         cd ${RunDirs}/jacobian_runs
 
-        if ! "$isAWS"; then
-            # Load environment with modules for compiling GEOS-Chem Classic
-            source ${GEOSChemEnv} 
-        fi
-
         # Submit job to job scheduler
         source submit_jacobian_simulations_array.sh
 
@@ -213,11 +208,6 @@ run_jacobian() {
 
         # Run the prior simulation
         cd ${JacobianRunsDir}
-            
-        if ! "$isAWS"; then
-            # Load environment with modules for compiling GEOS-Chem Classic
-            source ${GEOSChemEnv}
-        fi
 
         # Submit prior simulation to job scheduler
         printf "\n=== SUBMITTING PRIOR SIMULATION ===\n"

--- a/src/components/posterior_component/posterior.sh
+++ b/src/components/posterior_component/posterior.sh
@@ -94,11 +94,6 @@ setup_posterior() {
 run_posterior() {
     posterior_start=$(date +%s)
     cd ${RunDirs}/posterior_run
-    
-    if ! "$isAWS"; then
-        # Load environment with modules for compiling GEOS-Chem Classic
-        source ${GEOSChemEnv}
-    fi
 
     if "$OptimizeBCs"; then
         if "$KalmanMode"; then

--- a/src/components/setup_component/setup.sh
+++ b/src/components/setup_component/setup.sh
@@ -22,29 +22,7 @@ setup_imi() {
     SpinupEnd=${StartDate}
 
     # Use global boundary condition files for initial conditions
-    UseBCsForRestart=true
-
-    printf "\nActivating conda environment: ${CondaEnv}\n"
-    if "$isAWS"; then
-        # Get max process count for spinup, production, and run_inversion scripts
-        output=$(echo $(slurmd -C))
-        array=($output)
-        cpu_str=$(echo ${array[1]})
-        cpu_count=$(echo ${cpu_str:5})
-
-        # With sbatch reduce cpu_count by 1 to account for parent sbatch process 
-        # using 1 core 
-        if "$UseSlurm"; then 
-            cpu_count="$((cpu_count-1))"
-        fi
-
-        # Source Conda environment file
-        source $CondaFile
-
-    fi
-
-    # Activate Conda environment
-    conda activate $CondaEnv
+    UseBCsForRestart=true    
 
     ##=======================================================================
     ## Download Boundary Conditions files if requested


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard

### Describe the update

This is related to running the IMI at Harvard on Cannon. For @laestrada and I, the combination of first sourcing the GEOS-Chem environment file and then activating the conda environment (an alias for micromamba in our case) results in GEOS-Chem not being able to run (`./gcclassic: error while loading shared libraries: libnetcdf.so.18: cannot open shared object file: No such file or directory`).

This order was introduced in https://github.com/geoschem/integrated_methane_inversion/commit/7c57d9182660319e52f45c09c8ec5b9286ef4650. This PR is a fix that makes sure the Conda environment and GEOS-Chem environment file are only activated a single time each (now in `run_imi.sh`) and than the order is Conda then GEOS-Chem environment file. I have tested this on Cannon with this bash script:

```
#!/bin/bash

git clone https://github.com/geoschem/integrated_methane_inversion.git
cd integrated_methane_inversion
git checkout bugfix/environment-file-activation

sed -i -e "s|SetupSpinupRun: false|SetupSpinupRun: true|g" \
    -e "s|SetupJacobianRuns: false|SetupJacobianRuns: true|g" \
    -e "s|SetupInversion: false|SetupInversion: true|g" \
    -e "s|SetupPosteriorRun: false|SetupPosteriorRun: true|g" \
    -e "s|DoSpinup: false|DoSpinup: true|g" \
    -e "s|DoJacobian: false|DoJacobian: true|g" \
    -e "s|DoInversion: false|DoInversion: true|g" \
    -e "s|DoPosterior: false|DoPosterior: true|g" envs/Harvard-Cannon/config.harvard-cannon.yml
    
sbatch --mem 16000 -c 8 -t 0-06:00 -p seas_compute,sapphire run_imi.sh envs/Harvard-Cannon/config.harvard-cannon.yml
```

I also moved the AWS Conda activate from `setup.sh` to `run_imi.sh` but can't test this. @laestrada, let me know if what I did looks okay.