### PR TITLE
update bc smoothing to use -30 day smoothing as a backup

### DIFF
--- a/src/write_BCs/write_boundary_conditions.py
+++ b/src/write_BCs/write_boundary_conditions.py
@@ -141,9 +141,15 @@ def calculate_bias(daily_means):
                         ).mean(skipna=True)
 
     # Smooth temporally
-    bias = bias.rolling(time=15,            # average 15 days back in time (including the time we are centered on)
+    bias_15 = bias.rolling(time=15,            # average 15 days back in time (including the time we are centered on)
                         min_periods=1,      # only one of the time values must have a value to not output NaN
                     ).mean(skipna=True)
+
+    bias_30 = bias.rolling(time=30,            # average 30 days back in time (including the time we are centered on)
+                        min_periods=1,      # only one of the time values must have a value to not output NaN
+                    ).mean(skipna=True)
+    
+    bias = bias_15.fillna(bias_30)          # fill in NaN values with the 30 day average
 
     # Create a dataarray with latitudinal average for each time step
     # We will fill the NaN values in bias with these averages


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
The tropomi smoothed boundary conditions use a -15 day temporal smoothing to generate the bias correction. There are two periods in the tropomi record with greater than 15 day gaps in observations (21 and 29 day gaps). This causes anomalously low boundary conditions for these periods with corrections that can reach >100ppb corrections. In this PR, I update the temporal smoothing to default to -15 day smoothing, but in the case of data gaps, we fill in grid cells with the -30 day smoothing. 

