### PR TITLE
Bugfix/run_inversion.sh error handling

### DIFF
--- a/src/inversion_scripts/run_inversion.sh
+++ b/src/inversion_scripts/run_inversion.sh
@@ -2,11 +2,23 @@
 
 #SBATCH -N 1
 #SBATCH -o run_inversion_%j.out
-#SBATCH -e run_inversion_%j.err
 
 ##=======================================================================
 ## Parse config.yml file
 ##=======================================================================
+
+send_error() {
+    file=`basename "$0"`
+    printf "\nInversion Error: on line number ${1} of ${file}: IMI exiting."
+    echo "Error Status: 1" > .error_status_file.txt
+    exit 1
+}
+
+# remove error status file if present
+rm -f .error_status_file.txt
+
+# trap and exit on errors
+trap 'send_error $LINENO' ERR
 
 printf "\n=== PARSING CONFIG FILE ===\n"
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
Previously if the run_inversion.sh script failed with an error, the inversion workflow would continue despite the error because run_inversion.sh is run via an sbatch job. 

To fix this, on any non-zero exit code this script writes out a hidden error file that the inversion workflow reads and errors out on. This is how we handle other failed sbatch jobs eg. jacobian runs in the IMI.