### PR TITLE
Fix sbatch within sbatch printing

### DIFF
--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -222,7 +222,9 @@ run_jacobian() {
 
         # Submit prior simulation to job scheduler
         printf "\n=== SUBMITTING PRIOR SIMULATION ===\n"
-        sbatch -W run_prior_simulation.sh; wait;
+        sbatch -W -o imi_output.tmp run_prior_simulation.sh; wait;
+        cat imi_output.tmp >> ${InversionPath}/imi_output.log
+        rm imi_output.tmp
         printf "=== DONE PRIOR SIMULATION ===\n"
 
         # Get Jacobian scale factors

--- a/src/components/preview_component/preview.sh
+++ b/src/components/preview_component/preview.sh
@@ -109,7 +109,10 @@ run_preview() {
         -c $SimulationCPUs \
         -t $RequestedTime \
         -p $SchedulerPartition \
+        -o imi_output.tmp \
         -W $preview_file $InversionPath $config_path $state_vector_path $preview_dir $tropomi_cache; wait;
+        cat imi_output.tmp >> ${InversionPath}/imi_output.log
+        rm imi_output.tmp
     else
         python $preview_file $InversionPath $config_path $state_vector_path $preview_dir $tropomi_cache
     fi

--- a/src/components/statevector_component/aggregation.py
+++ b/src/components/statevector_component/aggregation.py
@@ -481,9 +481,6 @@ if __name__ == "__main__":
     tropomi_cache = sys.argv[5]
     kf_index = int(sys.argv[6]) if len(sys.argv) > 6 else None
     config = yaml.load(open(config_path), Loader=yaml.FullLoader)
-    output_file = open(f"{inversion_path}/imi_output.log", "a")
-    sys.stdout = output_file
-    sys.stderr = output_file
 
     original_clusters = xr.open_dataset(state_vector_path)
     print("Starting aggregation")

--- a/src/components/statevector_component/statevector.sh
+++ b/src/components/statevector_component/statevector.sh
@@ -93,7 +93,10 @@ reduce_dimension() {
         -c $SimulationCPUs \
         -t $RequestedTime \
         -p $SchedulerPartition \
+        -o imi_output.tmp \
         -W "${python_args[@]}"; wait;
+        cat imi_output.tmp >> ${InversionPath}/imi_output.log
+        rm imi_output.tmp
     else
         python "${python_args[@]}"
     fi

--- a/src/geoschem_run_scripts/ch4_run.template
+++ b/src/geoschem_run_scripts/ch4_run.template
@@ -38,9 +38,6 @@ echo '===> Run ended at' `date` >> $log
 # Move restart files to clean up run directory
 #mv GEOSChem_restart.* ./Restarts/
 
-# These files are not used in CH4 simulations
-rm HEMCO_restart.*
-
 # Exit normally
 exit 0
 #EOC

--- a/src/geoschem_run_scripts/run_jacobian_simulations.sh
+++ b/src/geoschem_run_scripts/run_jacobian_simulations.sh
@@ -19,14 +19,12 @@ else
     xstr="${x}"
 fi
 
-output_log_file={InversionPath}/imi_output.log
-
 # This checks for the presence of the error status file. If present, this indicates 
 # a prior jacobian exited with an error, so this jacobian will not run
 FILE=.error_status_file.txt
 if test -f "$FILE"; then
     echo "$FILE exists. Exiting."
-    echo "jacobian simulation: ${xstr} exited without running." >> $output_log_file
+    echo "jacobian simulation: ${xstr} exited without running."
     exit 1
 fi
 
@@ -46,11 +44,11 @@ if {ReDoJacobian}; then
     cd OutputDir
 
     if test -f "$LastConcFile"; then
-        echo "Not re-running jacobian simulation: ${xstr}" >> $output_log_file
+        echo "Not re-running jacobian simulation: ${xstr}"
         exit 0
     else
         ### Run GEOS-Chem in the directory corresponding to the cluster Id
-        echo "Re-running jacobian simulation: ${xstr}" >> $output_log_file
+        echo "Re-running jacobian simulation: ${xstr}"
         cd ..
         ./{RunName}_${xstr}.run
         # save the exit code of the jacobian simulation cmd
@@ -72,11 +70,11 @@ fi
 if [ $retVal -ne 0 ]; then
     rm -f .error_status_file.txt
     echo "Error Status: $retVal" > ../.error_status_file.txt
-    echo "jacobian simulation: ${xstr} exited with error code: $retVal" >> $output_log_file
-    echo "Check the log file in the ${RUNDIR}/{RunName}_${xstr} directory for more details." >> $output_log_file
+    echo "jacobian simulation: ${xstr} exited with error code: $retVal"
+    echo "Check the log file in the ${RUNDIR}/{RunName}_${xstr} directory for more details."
     exit $retVal
 fi
 
-echo "finished jacobian simulation: ${xstr}" >> $output_log_file
+echo "finished jacobian simulation: ${xstr}"
 
 exit 0

--- a/src/geoschem_run_scripts/run_prior_simulation.sh
+++ b/src/geoschem_run_scripts/run_prior_simulation.sh
@@ -12,14 +12,12 @@ RUNDIR=$(pwd -P)
 ### Get current task ID
 xstr="0000"
 
-output_log_file={InversionPath}/imi_output.log
-
 # This checks for the presence of the error status file. If present, this indicates 
 # a previous prior sim exited with an error, so this prior will not run
 FILE=.error_status_file.txt
 if test -f "$FILE"; then
     echo "$FILE exists. Exiting."
-    echo "prior simulation: ${xstr} exited without running." >> $output_log_file
+    echo "prior simulation: ${xstr} exited without running."
     exit 1
 fi
 
@@ -37,11 +35,11 @@ retVal=$?
 if [ $retVal -ne 0 ]; then
     rm -f .error_status_file.txt
     echo "Error Status: $retVal" > ../.error_status_file.txt
-    echo "prior simulation: ${xstr} exited with error code: $retVal" >> $output_log_file
-    echo "Check the log file in the ${RUNDIR}/{RunName}_${xstr} directory for more details." >> $output_log_file
+    echo "prior simulation: ${xstr} exited with error code: $retVal"
+    echo "Check the log file in the ${RUNDIR}/{RunName}_${xstr} directory for more details."
     exit $retVal
 fi
 
-echo "finished prior simulation: ${xstr}" >> $output_log_file
+echo "finished prior simulation: ${xstr}"
 
 exit 0

--- a/src/geoschem_run_scripts/submit_jacobian_simulations_array.sh
+++ b/src/geoschem_run_scripts/submit_jacobian_simulations_array.sh
@@ -8,4 +8,9 @@ sbatch --array={START}-{END}{JOBS} --mem $JacobianMemory \
 -c $JacobianCPUs \
 -t $RequestedTime \
 -p $SchedulerPartition \
+-o imi_output.tmp \
+--open-mode=append \
 -W run_jacobian_simulations.sh
+
+cat imi_output.tmp >> {InversionPath}/imi_output.log
+rm imi_output.tmp

--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -110,10 +110,6 @@ def imi_preview(
 
     # Read config file
     config = yaml.load(open(config_path), Loader=yaml.FullLoader)
-    # redirect output to log file
-    output_file = open(f"{inversion_path}/imi_output.log", "a")
-    sys.stdout = output_file
-    sys.stderr = output_file
 
     # Open the state vector file
     state_vector = xr.load_dataset(state_vector_path)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard

### Describe the update

It can be shown with a simple bash script like the one below that if you run a job using sbatch with output to `out.log` and then start another job within using sbatch again and try to append to the same `out.log` that the output of the inner job will be overwritten by the outer job. I find that this is only true if the two jobs take place on different nodes. I'm not sure if this is a SLURM bug or intended behavior.
```
#!/bin/bash

#SBATCH -p test
#SBATCH -o "out.log"

echo "1"
sbatch -W -p sapphire --wrap "echo '2' >> out.log"
echo "3"
```

In the IMI, this is responsible for the behavior seen in #136 and #187. This PR fixes this by writing to a file called `imi_output.tmp` when sbatch is called inside of the `run_imi.sh` sbatch. Then, `imi_output.tmp` is appended to `imi_output.log` before being deleted.