### PR TITLE
bugfix/geoschem domain: fix bug in specification of geoschem domain for some custom domains

### DIFF
--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -73,8 +73,8 @@ setup_template() {
 
     # Adjust lat/lon bounds because GEOS-Chem defines the domain 
     # based on grid cell edges (not centers) for the lat/lon bounds
-    Lons=$(calculate_geoschem_domain lon ${RunDirs}/StateVector.nc ${LonMinInvDomain} ${LonMaxInvDomain})
-    Lats=$(calculate_geoschem_domain lon ${RunDirs}/StateVector.nc ${LatMinInvDomain} ${LatMaxInvDomain})
+    Lons="${LonMinInvDomain}, ${LonMaxInvDomain}"
+    Lats=$(calculate_geoschem_domain lat ${RunDirs}/StateVector.nc ${LatMinInvDomain} ${LatMaxInvDomain})
 
     # Modify geoschem_config.yml based on settings in config.yml
     sed -i -e "s:20190101:${StartDate}:g" \


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
This fixes a bug with the specification of the longitude bounds for the geoschem domain. According to the geoschem [documentation](https://geos-chem.readthedocs.io/en/latest/gcclassic-user-guide/geoschem-config.html#cmdoption-arg-latitude), the northernmost/southernmost grid boxes are half the size of others for both merra2 and geosfp. This only affects latitudes. Previously we were accounting for this for both lat and lon. This removes the correction for longitude. 