### PR TITLE
feature/imi-metadata collect geoschem version, IMI version, and tropomi retrieval version

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -141,7 +141,7 @@ TROPOMI_PROCESSOR_VERSION=$(grep 'VALID_TROPOMI_PROCESSOR_VERSIONS =' src/utilit
 
 # copy config file to run directory and add some run information to it for reference
 cp $ConfigFile "${RunDirs}/config_${RunName}.yml"
-echo "## ================= IMI run information =================" >>"${RunDirs}/config_${RunName}.yml"
+echo "## ================== IMI run information ==================" >>"${RunDirs}/config_${RunName}.yml"
 echo "# Run with IMI version: ${IMI_VERSION}" >>"${RunDirs}/config_${RunName}.yml"
 echo "# GEOS-Chem version: ${GEOSCHEM_VERSION}" >>"${RunDirs}/config_${RunName}.yml"
 echo "# TROPOMI/blended processor version(s): ${TROPOMI_PROCESSOR_VERSION}" >>"${RunDirs}/config_${RunName}.yml"

--- a/run_imi.sh
+++ b/run_imi.sh
@@ -128,12 +128,29 @@ ConfigPath=${InversionPath}/${ConfigFile}
 # add inversion path to python path
 export PYTHONPATH=${PYTHONPATH}:${InversionPath}
 
+# Make run directory
+mkdir -p -v ${RunDirs}
+
+# Set/Collect information about the GEOS-Chem version, IMI version,
+# and TROPOMI processor version
+GEOSCHEM_VERSION=14.2.3
+IMI_VERSION=$(git describe --tags)
+TROPOMI_PROCESSOR_VERSION=$(grep 'VALID_TROPOMI_PROCESSOR_VERSIONS =' src/utilities/download_TROPOMI.py |
+    sed 's/VALID_TROPOMI_PROCESSOR_VERSIONS = //' |
+    tr -d '"')
+
+# copy config file to run directory and add some run information to it for reference
+cp $ConfigFile "${RunDirs}/config_${RunName}.yml"
+echo "## ================= IMI run information =================" >>"${RunDirs}/config_${RunName}.yml"
+echo "# Run with IMI version: ${IMI_VERSION}" >>"${RunDirs}/config_${RunName}.yml"
+echo "# GEOS-Chem version: ${GEOSCHEM_VERSION}" >>"${RunDirs}/config_${RunName}.yml"
+echo "# TROPOMI/blended processor version(s): ${TROPOMI_PROCESSOR_VERSION}" >>"${RunDirs}/config_${RunName}.yml"
+
 ##=======================================================================
 ##  Download the TROPOMI data
 ##=======================================================================
 
 # Download TROPOMI or blended dataset from AWS
-mkdir -p -v ${RunDirs}
 tropomiCache=${RunDirs}/satellite_data
 if "$isAWS"; then
     mkdir -p -v $tropomiCache

--- a/src/components/setup_component/setup.sh
+++ b/src/components/setup_component/setup.sh
@@ -103,7 +103,7 @@ setup_imi() {
     if [ ! -d "GCClassic" ]; then
         git clone https://github.com/geoschem/GCClassic.git
         cd GCClassic
-        git checkout 14.2.3
+        git checkout ${GEOSCHEM_VERSION}
         git submodule update --init --recursive
         cd ..
     else

--- a/src/utilities/download_TROPOMI.py
+++ b/src/utilities/download_TROPOMI.py
@@ -17,6 +17,8 @@ from botocore.client import Config
 #     $ python download_TROPOMI.py 20190101 20190214 TROPOMI_data
 
 s3 = None
+VALID_TROPOMI_PROCESSOR_VERSIONS = ["020400", "020500", "020600"]
+
 def initialize_boto3():
     """
     Initialize s3 service with boto3
@@ -91,9 +93,7 @@ def get_s3_paths(start_date, end_date, bucket):
 
     # We only want files that are v02.04.00, v02.05.00, or v02.06.00.
     # Also make sure the collection number is 03 to account for some duplicates.
-    df = df.loc[((df["ProcessorVersion"] == "020400") |
-                 (df["ProcessorVersion"] == "020500") |
-                 (df["ProcessorVersion"] == "020600"))]
+    df.loc[df["ProcessorVersion"].isin(VALID_TROPOMI_PROCESSOR_VERSIONS)]
     df = df.drop_duplicates(subset=["Name","ModificationDate"])
     df = df.loc[df["CollectionNumber"] == "03"].reset_index(drop=True)
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
The goal of this feature is to reliably be able to identify what version of the IMI, geoschem version, and TROPOMI retrieval was used for a particular IMI run based solely on the config file. This will aid in reproducing inversion results.

The update copies the config file to the run directory and adds information like:
```
## ================== IMI run information ==================
# Run with IMI version: imi-1.2.1-2-g262c8be
# GEOS-Chem version: 14.2.3
# TROPOMI/blended processor version(s): [020400, 020500, 020600]
```
