### PR TITLE
Bugfix for TROPOMI operator retrieval times

### DIFF
--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -401,3 +401,12 @@ def get_posterior_emissions(prior, scale):
     # Add the original soil sink back to the total emissions
     posterior["EmisCH4_Total"] = posterior["EmisCH4_Total"] + prior_soil_sink
     return posterior
+
+def get_strdate(current_time, date_threshold):
+    # round observation time to nearest hour
+    strdate = current_time.round("60min").strftime("%Y%m%d_%H")
+    # Unless it equals the date threshold (hour 00 after the inversion period)
+    if strdate == date_threshold:
+        strdate = current_time.floor("60min").strftime("%Y%m%d_%H")
+ 
+    return strdate


### PR DESCRIPTION
### Name and Institution (Required)

Name: Megan He
Institution: Harvard ACMG

### Describe the update

This addresses the bug in #211 in which retrieval times can be rounded to a time outside of the period of interest due to rounding to the nearest hour. In the TROPOMI operator, an observation within the GC start and end dates can be rounded to be equal to the end date 00 hour, which is problematic because GC does not output for this hour. To avoid this problem, those dates are floor rounded. 