### PR TITLE
Bugfix/prior emissions: switch to daily precompiled emissions

### DIFF
--- a/src/components/jacobian_component/make_perturbation_sf.py
+++ b/src/components/jacobian_component/make_perturbation_sf.py
@@ -112,15 +112,15 @@ def make_perturbation_sf(config, period_number, perturb_value=1e-8):
     )
     
     # get start and end dates
-    start_date = config["StartDate"]
-    end_date = config["EndDate"]
+    start_date = str(config["StartDate"])
+    end_date = str(config["EndDate"])
 
     # jacobian rundir path
     jacobian_dir = os.path.join(base_directory, "jacobian_runs")
 
     # find the hemco emissions file for the period
     prior_cache = os.path.join(base_directory, "prior_run/OutputDir")
-    if config["KalmanMode"] == "true":
+    if config["KalmanMode"]:
         hemco_emis = get_period_mean_emissions(prior_cache, period_number, os.path.join(base_directory, "periods.csv"))
     else:   
         hemco_emis = get_mean_emissions(start_date, end_date, prior_cache)

--- a/src/components/jacobian_component/make_perturbation_sf.py
+++ b/src/components/jacobian_component/make_perturbation_sf.py
@@ -11,6 +11,8 @@ import glob
 import yaml
 import xarray as xr
 import numpy as np
+import pandas as pd
+from src.inversion_scripts.utils import get_mean_emissions, get_period_mean_emissions
 
 
 def update_jacobian_perturbation_files(jacobian_dir, state_vector_labels, flat_sf):
@@ -61,16 +63,13 @@ def update_jacobian_perturbation_files(jacobian_dir, state_vector_labels, flat_s
                         file.writelines(lines)
 
 
-def calculate_sfs(state_vector, hemco_emis_path, target_emission=1e-8):
+def calculate_sfs(state_vector, emis_prior, target_emission=1e-8):
     """
     Calculate the scale factors to perturb each state vector
     element by based on the target_emission. Return a flat
     numpy array of the scale factors indexed by state vector
     element.
     """
-    # load the prior emissions dataset
-    emis_prior = xr.open_dataset(hemco_emis_path)
-
     # create a sf dataset with the same structure as the state vector
     sf = state_vector.copy()
     sf = sf.rename({"StateVector": "ScaleFactor"})
@@ -111,21 +110,26 @@ def make_perturbation_sf(config, period_number, perturb_value=1e-8):
     base_directory = os.path.expandvars(
         os.path.join(config["OutputPath"], config["RunName"])
     )
+    
+    # get start and end dates
+    start_date = config["StartDate"]
+    end_date = config["EndDate"]
 
     # jacobian rundir path
     jacobian_dir = os.path.join(base_directory, "jacobian_runs")
 
     # find the hemco emissions file for the period
     prior_cache = os.path.join(base_directory, "prior_run/OutputDir")
-    hemco_list = [f for f in os.listdir(prior_cache) if "HEMCO_sa_diagnostics" in f]
-    hemco_list.sort()
-    hemco_emis_path = os.path.join(prior_cache, hemco_list[period_number - 1])
+    if config["KalmanMode"] == "true":
+        hemco_emis = get_period_mean_emissions(prior_cache, period_number, os.path.join(base_directory, "periods.csv"))
+    else:   
+        hemco_emis = get_mean_emissions(start_date, end_date, prior_cache)
 
     # load the state vector dataset
     state_vector = xr.load_dataset(os.path.join(base_directory, "StateVector.nc"))
 
     # calculate the scale factors to perturb each state vector element by
-    flat_sf = calculate_sfs(state_vector, hemco_emis_path, perturb_value)
+    flat_sf = calculate_sfs(state_vector, hemco_emis, perturb_value)
 
     # update jacobian perturbation files with new scale factors
     # before we run the jacobian simulations

--- a/src/components/kalman_component/kalman.sh
+++ b/src/components/kalman_component/kalman.sh
@@ -102,8 +102,7 @@ run_period() {
     # check if precomputed prior emissions for this period exists already
     if [[ ! -f ${RunDirs}/prior_run/OutputDir/HEMCO_sa_diagnostics.${StartDate_i}0000.nc ]]; then
         printf "\nNeed to compute prior emissions for this period. Running hemco standalone simulation.\n"
-        # TODO: switch to use enddate- this just computes the first hour of emissions
-        run_hemco_sa $StartDate_i $StartDate_i
+        run_hemco_sa $StartDate_i $EndDate_i
     fi
 
     # Set dates in geoschem_config.yml for prior, perturbation, and posterior runs

--- a/src/components/kalman_component/prepare_sf.py
+++ b/src/components/kalman_component/prepare_sf.py
@@ -1,9 +1,11 @@
 import xarray as xr
+import pandas as pd
 import os
 import sys
 import numpy as np
 import yaml
 from src.inversion_scripts.utils import sum_total_emissions, get_posterior_emissions
+from src.inversion_scripts.utils import get_period_mean_emissions
 
 
 def prepare_sf(config_path, period_number, base_directory, nudge_factor):
@@ -31,27 +33,19 @@ def prepare_sf(config_path, period_number, base_directory, nudge_factor):
     unit_sf_path = os.path.join(base_directory, "unit_sf.nc")
     statevector_path = os.path.join(base_directory, "StateVector.nc")
     original_prior_cache = os.path.join(base_directory, "prior_run/OutputDir")
-    jacobian_dir = os.path.join(base_directory, "jacobian_runs")
-    prior_sim = [r for r in os.listdir(jacobian_dir) if "0000" in r][0]
-    prior_cache = os.path.join(base_directory, f"jacobian_runs/{prior_sim}/OutputDir")
-    diags_files = [
-        f for f in os.listdir(original_prior_cache) if "HEMCO_sa_diagnostics" in f
-    ]
-    diags_files.sort()
-    diags_file = diags_files[0]
-    diags_path = os.path.join(original_prior_cache, diags_file)
+    
+    # Get the original emissions for the first inversion period
+    periods_csv_path = os.path.join(base_directory, "periods.csv")
+    original_emis_ds = get_period_mean_emissions(original_prior_cache, 1, periods_csv_path)
 
     # Get state vector, grid-cell areas, mask
     statevector = xr.load_dataset(statevector_path)
-    areas = xr.load_dataset(diags_path)["AREA"]
+    areas = original_emis_ds["AREA"]
     state_vector_labels = statevector["StateVector"]
     last_ROI_element = int(
         np.nanmax(state_vector_labels.values) - config["nBufferClusters"]
     )
     mask = state_vector_labels <= last_ROI_element
-
-    # Get original emissions from hemco run, for first inversion period
-    original_emis_ds = xr.load_dataset(diags_path)
 
     # Initialize unit scale factors
     sf = xr.load_dataset(unit_sf_path)
@@ -69,25 +63,8 @@ def prepare_sf(config_path, period_number, base_directory, nudge_factor):
             # Get the original HEMCO emissions for period p
             # Note: we remove soil absorption from the prior for our nudging operations
             # since it is not optimized in the inversion.
-            hemco_emis_path = os.path.join(original_prior_cache, diags_files[p - 1])  # p-1 index
-            original_emis_ds = xr.load_dataset(hemco_emis_path)
-
-            # check if data variable ExcludeSoilAbsorb is not in the dataset
-            # if not, create new Total emis variable and overwrite the original
-            # file to include this additional data variable
-            if "EmisCH4_Total_ExclSoilAbs" not in original_emis_ds.data_vars:
-                original_emis_ds["EmisCH4_Total_ExclSoilAbs"] = (
-                    original_emis_ds["EmisCH4_Total"]
-                    - original_emis_ds["EmisCH4_SoilAbsorb"]
-                )
-                original_emis_ds["EmisCH4_Total_ExclSoilAbs"].attrs = original_emis_ds[
-                    "EmisCH4_Total"
-                ].attrs
-                original_emis_ds.to_netcdf(hemco_emis_path)
-
-            original_emis = original_emis_ds["EmisCH4_Total_ExclSoilAbs"].isel(
-                time=0, drop=True
-            )
+            original_emis_ds = get_period_mean_emissions(original_prior_cache, p, periods_csv_path)
+            original_emis = original_emis_ds["EmisCH4_Total_ExclSoilAbs"]
 
             # Get the gridded posterior for period p
             gridded_posterior_filename = (
@@ -139,9 +116,7 @@ def prepare_sf(config_path, period_number, base_directory, nudge_factor):
         )
 
     # Print the current total emissions in the region of interest
-    emis = get_posterior_emissions(original_emis_ds, sf)["EmisCH4_Total"].isel(
-        time=0, drop=True
-    )
+    emis = get_posterior_emissions(original_emis_ds, sf)["EmisCH4_Total"]
     total_emis = sum_total_emissions(emis, areas, mask)
     print(f"Total prior emission = {total_emis} Tg a-1")
 

--- a/src/components/prior_component/prior.sh
+++ b/src/components/prior_component/prior.sh
@@ -111,12 +111,7 @@ fi' runHEMCO.sh
 
     printf "\nSubmitting prior emissions hemco simulation\n\n"
 
-    if "$KalmanMode"; then
-        kalman_end=$(date -d "${StartDate} +${UpdateFreqDays} days" +"%Y%m%d")
-        run_hemco_sa $StartDate $kalman_end
-    else
-        run_hemco_sa $StartDate $EndDate
-    fi
+    run_hemco_sa $StartDate $EndDate
 
     printf "\nDone prior emissions hemco simulation\n\n"
 

--- a/src/components/prior_component/prior.sh
+++ b/src/components/prior_component/prior.sh
@@ -59,6 +59,7 @@ run_prior() {
     sed -i -e "/DiagnFreq:           00000100 000000/d" \
         -e "/Negative values:     0/d" HEMCO_sa_Config.rc
     sed -i -e "s/METEOROLOGY            :       true/METEOROLOGY            :       false/g" HEMCO_Config.rc
+    sed -i -e "s|DiagnFreq:                   Monthly|DiagnFreq:                   Daily|g" HEMCO_Config.rc
     sed -i -e "/#SBATCH -c 8/d" runHEMCO.sh
     sed -i -e "/#SBATCH -t 0-12:00/d" runHEMCO.sh
     sed -i -e "/#SBATCH -p huce_intel/d" runHEMCO.sh

--- a/src/components/prior_component/prior.sh
+++ b/src/components/prior_component/prior.sh
@@ -59,7 +59,7 @@ run_prior() {
     sed -i -e "/DiagnFreq:           00000100 000000/d" \
         -e "/Negative values:     0/d" HEMCO_sa_Config.rc
     sed -i -e "s/METEOROLOGY            :       true/METEOROLOGY            :       false/g" HEMCO_Config.rc
-    sed -i -e "s|DiagnFreq:                   Monthly|DiagnFreq:                   Daily|g" HEMCO_Config.rc
+    sed -i -e "s|DiagnFreq:                   End|DiagnFreq:                   Daily|g" HEMCO_Config.rc
     sed -i -e "/#SBATCH -c 8/d" runHEMCO.sh
     sed -i -e "/#SBATCH -t 0-12:00/d" runHEMCO.sh
     sed -i -e "/#SBATCH -p huce_intel/d" runHEMCO.sh

--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -118,7 +118,7 @@ setup_template() {
     sed -i -e "s:\$ROOT/SAMPLE_BCs/v2021-07/CH4:${fullBCpath}:g" HEMCO_Config.rc
 
     # If reading total prior emissions (as in the jacobian and posterior), read a new file each month
-    sed -i -e "s|EmisCH4_Total \$YYYY/\$MM/\$DD/0|EmisCH4_Total 1900-2050/1-12/1/0|g" HEMCO_Config.rc
+    sed -i -e "s|EmisCH4_Total \$YYYY/\$MM/\$DD/0|EmisCH4_Total 1900-2050/1-12/1-31/0|g" HEMCO_Config.rc
 
     # Modify HISTORY.rc - comment out diagnostics that aren't needed
     sed -i -e "s:'CH4':#'CH4':g" \

--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -28,6 +28,8 @@ from src.inversion_scripts.utils import (
     filter_blended,
     calculate_area_in_km,
     calculate_superobservation_error,
+    get_mean_emissions,
+    get_posterior_emissions,
 )
 from joblib import Parallel, delayed
 from src.inversion_scripts.operators.TROPOMI_operator import (
@@ -421,19 +423,12 @@ def estimate_averaging_kernel(
     # ----------------------------------
     # Total prior emissions
     # ----------------------------------
-
-    # Prior emissions
-    prior_cache = os.path.join(config["OutputPath"], config["RunName"], "prior_run/OutputDir")
-    hemco_diags_file = [
-        f for f in os.listdir(prior_cache) if "HEMCO_sa_diagnostics" in f
-    ][0]
-    prior_pth = os.path.join(prior_cache, hemco_diags_file)
-    prior = xr.load_dataset(prior_pth)["EmisCH4_Total"].isel(time=0)
-
     # Start and end dates of the inversion
     startday = str(config["StartDate"])
     endday = str(config["EndDate"])
 
+    # Prior emissions
+    prior_cache = os.path.join(config["OutputPath"], config["RunName"], "prior_run/OutputDir")
     # adjustments for when performing for dynamic kf clustering
     if kf_index is not None:
         # use different date range for KF inversion if kf_index is not None
@@ -444,10 +439,15 @@ def estimate_averaging_kernel(
 
         # use the nudged (prior) emissions for generating averaging kernel estimate
         sf = xr.load_dataset(f"{rundir_path}archive_sf/prior_sf_period{kf_index}.nc")
-        prior = sf["ScaleFactor"] * prior
+        prior_ds = get_mean_emissions(startday, endday, prior_cache)
+        prior_ds = get_posterior_emissions(prior_ds, sf)
+    else:
+        prior_ds = get_mean_emissions(startday, endday, prior_cache)
+        
+    prior = prior_ds["EmisCH4_Total"]
 
     # Compute total emissions in the region of interest
-    areas = xr.load_dataset(prior_pth)["AREA"]
+    areas = prior_ds["AREA"]
     total_prior_emissions = sum_total_emissions(prior, areas, mask)
     outstring1 = (
         f"Total prior emissions in region of interest = {total_prior_emissions} Tg/y \n"

--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -1,13 +1,16 @@
+import os
+import pickle
+from datetime import datetime, timedelta
 import numpy as np
+import xarray as xr
+import cartopy
+import cartopy.crs as ccrs
 from shapely.geometry.polygon import Polygon
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
-from pyproj import Geod
-import cartopy
-import cartopy.crs as ccrs
-import pickle
-import csv
 from matplotlib.lines import Line2D
+from pyproj import Geod
+import pandas as pd
 
 
 def save_obj(obj, name):
@@ -410,3 +413,53 @@ def get_strdate(current_time, date_threshold):
         strdate = current_time.floor("60min").strftime("%Y%m%d_%H")
  
     return strdate
+
+
+def filter_prior_files(filenames, start_date, end_date):
+    """
+    Filter a list of HEMCO diagnostic files based on the specified date range.
+    """
+    # Parse the input dates
+    start_date = datetime.strptime(start_date, "%Y%m%d")
+    end_date = datetime.strptime(end_date, "%Y%m%d") - timedelta(days=1)
+
+    filtered_files = []
+    for file in filenames:
+        # Extract the date part from the filename
+        date_str = file.split('.')[1]
+        file_date = datetime.strptime(date_str, "%Y%m%d%H%M")
+
+        # Check if the file date is within the specified range
+        if start_date <= file_date <= end_date:
+            # Create a key for the year and month
+            year_month = file_date.strftime("%Y%m")
+            # Only add the first file encountered for each month
+            filtered_files.append(file)
+    
+    return filtered_files
+    
+def get_mean_emissions(start_date, end_date, prior_cache_path):
+    """
+    Calculate the mean emissions for the specified date range.
+    """
+    # find all prior files in the specified date range
+    prior_files = [f for f in os.listdir(prior_cache_path) if "HEMCO_sa_diagnostics" in f]
+    prior_files = filter_prior_files(prior_files, start_date, end_date)
+    hemco_diags = [xr.load_dataset(os.path.join(prior_cache_path, f)) for f in prior_files]
+    
+    # concatenate all datasets and aggregate into the mean prior 
+    # emissions for the specified date range
+    prior_ds = xr.concat(hemco_diags, dim="time")
+    return prior_ds.mean(dim=["time"])
+
+def get_period_mean_emissions(prior_cache_path, period, periods_csv_path):
+    """
+    Calculate the mean emissions for the specified kalman period.
+    """
+    period_df = pd.read_csv(periods_csv_path)
+    period_df = period_df[period_df['period_number'] == period]
+    period_df.reset_index(drop=True, inplace=True)
+    start_date = str(period_df.loc[0,"Starts"])
+    end_date = str(period_df.loc[0,"Ends"])
+    return get_mean_emissions(start_date, end_date, prior_cache_path)
+    

--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -431,9 +431,6 @@ def filter_prior_files(filenames, start_date, end_date):
 
         # Check if the file date is within the specified range
         if start_date <= file_date <= end_date:
-            # Create a key for the year and month
-            year_month = file_date.strftime("%Y%m")
-            # Only add the first file encountered for each month
             filtered_files.append(file)
     
     return filtered_files

--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -444,7 +444,7 @@ def get_mean_emissions(start_date, end_date, prior_cache_path):
     """
     # find all prior files in the specified date range
     prior_files = [f for f in os.listdir(prior_cache_path) if "HEMCO_sa_diagnostics" in f]
-    prior_files = filter_prior_files(prior_files, start_date, end_date)
+    prior_files = filter_prior_files(prior_files, str(start_date), str(end_date))
     hemco_diags = [xr.load_dataset(os.path.join(prior_cache_path, f)) for f in prior_files]
     
     # concatenate all datasets and aggregate into the mean prior 

--- a/src/notebooks/kf_notebook.ipynb
+++ b/src/notebooks/kf_notebook.ipynb
@@ -191,7 +191,7 @@
     "\n",
     "# Posterior emissions\n",
     "posteriors_ds = [get_posterior_emissions(priors_ds[i], scales[i]) for i in range(num_periods)]\n",
-    "posteriors = [posterior[\"EmisCH4_Total\"].isel(time=0) for posterior in posteriors_ds]"
+    "posteriors = [posterior[\"EmisCH4_Total\"] for posterior in posteriors_ds]"
    ]
   },
   {

--- a/src/notebooks/kf_notebook.ipynb
+++ b/src/notebooks/kf_notebook.ipynb
@@ -17,7 +17,7 @@
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.dates as mdates\n",
     "\n",
-    "from period1.utils import plot_field, sum_total_emissions, plot_time_series, get_posterior_emissions"
+    "from period1.utils import plot_field, sum_total_emissions, plot_time_series, get_posterior_emissions, get_period_mean_emissions"
    ]
   },
   {
@@ -99,10 +99,7 @@
     "    else \"gridded_posterior.nc\"\n",
     ")\n",
     "\n",
-    "prior_prefix = (\n",
-    "    f\"./../jacobian_runs/{config['RunName']}_0000/OutputDir/HEMCO_diagnostics.\"\n",
-    ")\n",
-    "prior_paths = [f\"{prior_prefix}{date}0000.nc\" for date in start_dates]\n",
+    "prior_cache_path = f\"./../jacobian_runs/{config['RunName']}_0000/OutputDir/\"\n",
     "results_prefixes = sorted(\n",
     "    [\n",
     "        f\"./{name}/\"\n",
@@ -186,8 +183,8 @@
    "outputs": [],
    "source": [
     "# Prior emissions\n",
-    "priors_ds = [xr.load_dataset(prior_pth) for prior_pth in prior_paths]\n",
-    "priors = [prior[\"EmisCH4_Total\"].isel(time=0) for prior in priors_ds]\n",
+    "priors_ds = [get_period_mean_emissions(prior_cache_path, period+1, \"./../periods.csv\") for period in range(periods_df.shape[0])]\n",
+    "priors = [prior[\"EmisCH4_Total\"] for prior in priors_ds]\n",
     "\n",
     "# Optimized scale factors\n",
     "scales = [xr.load_dataset(sf_path) for sf_path in sf_paths]\n",
@@ -204,7 +201,7 @@
    "outputs": [],
    "source": [
     "# Calculate total emissions per interval in the region of interest\n",
-    "areas = [xr.load_dataset(prior_pth)[\"AREA\"] for prior_pth in prior_paths]\n",
+    "areas = [ds[\"AREA\"] for ds in priors_ds]\n",
     "\n",
     "total_prior_emissions_per_period = [\n",
     "    sum_total_emissions(priors[i], areas[i], mask) for i in range(num_periods)\n",

--- a/src/notebooks/kf_notebook.ipynb
+++ b/src/notebooks/kf_notebook.ipynb
@@ -99,7 +99,7 @@
     "    else \"gridded_posterior.nc\"\n",
     ")\n",
     "\n",
-    "prior_cache_path = f\"./../jacobian_runs/{config['RunName']}_0000/OutputDir/\"\n",
+    "prior_cache_path = f\"./../prior_run/OutputDir/\"\n",
     "results_prefixes = sorted(\n",
     "    [\n",
     "        f\"./{name}/\"\n",

--- a/src/notebooks/visualization_notebook.ipynb
+++ b/src/notebooks/visualization_notebook.ipynb
@@ -42,7 +42,7 @@
     "from functools import partial\n",
     "import pyproj\n",
     "\n",
-    "from utils import plot_field, load_obj, sum_total_emissions, count_obs_in_mask, get_posterior_emissions\n",
+    "from utils import plot_field, load_obj, sum_total_emissions, count_obs_in_mask, get_posterior_emissions, get_mean_emissions\n",
     "\n",
     "import warnings\n",
     "\n",
@@ -79,12 +79,14 @@
     "    period = int(os.getcwd().split(\"kf_inversions/period\")[-1])  # get current period\n",
     "    periods_df = pd.read_csv(\"./../../periods.csv\")\n",
     "    start_date = periods_df.iloc[period - 1, 0]\n",
+    "    end_date = periods_df.iloc[period - 1, 1]\n",
     "    prior_sf_pth = f\"{prior_prefix}/archive_sf/prior_sf_period{period}.nc\"\n",
     "else:\n",
     "    prior_prefix = \"./..\"\n",
     "    start_date = config[\"StartDate\"]\n",
+    "    end_date = config[\"EndDate\"]\n",
     "\n",
-    "prior_pth = f'{prior_prefix}/prior_run/OutputDir/HEMCO_sa_diagnostics.{start_date}0000.nc'\n",
+    "prior_cache = f'{prior_prefix}/prior_run/OutputDir/'\n",
     "\n",
     "\n",
     "satdat_dir = (\n",
@@ -197,7 +199,7 @@
    "outputs": [],
    "source": [
     "# Prior emissions\n",
-    "prior_ds = xr.load_dataset(prior_pth)\n",
+    "prior_ds = get_mean_emissions(start_date, end_date, prior_cache)\n",
     "prior = prior_ds[\"EmisCH4_Total\"].isel(time=0)\n",
     "\n",
     "if config[\"KalmanMode\"]:\n",
@@ -223,7 +225,7 @@
    "source": [
     "# Total emissions in the region of interest\n",
     "\n",
-    "areas = xr.load_dataset(prior_pth)[\"AREA\"]\n",
+    "areas = prior_ds[\"AREA\"]\n",
     "\n",
     "total_prior_emissions = sum_total_emissions(prior, areas, mask)\n",
     "total_posterior_emissions = sum_total_emissions(posterior, areas, mask)\n",
@@ -944,7 +946,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.12.2"
   },
   "vscode": {
    "interpreter": {

--- a/src/notebooks/visualization_notebook.ipynb
+++ b/src/notebooks/visualization_notebook.ipynb
@@ -200,13 +200,13 @@
    "source": [
     "# Prior emissions\n",
     "prior_ds = get_mean_emissions(start_date, end_date, prior_cache)\n",
-    "prior = prior_ds[\"EmisCH4_Total\"].isel(time=0)\n",
+    "prior = prior_ds[\"EmisCH4_Total\"]\n",
     "\n",
     "if config[\"KalmanMode\"]:\n",
     "    # properly apply nudged sfs to prior in Kalman mode\n",
     "    prior_sf = xr.load_dataset(prior_sf_pth)\n",
     "    prior_ds = get_posterior_emissions(prior_ds, prior_sf)\n",
-    "    prior = prior_ds[\"EmisCH4_Total\"].isel(time=0)\n",
+    "    prior = prior_ds[\"EmisCH4_Total\"]\n",
     "\n",
     "# Optimized scale factors\n",
     "scale_ds = xr.load_dataset(results_pth)\n",
@@ -214,7 +214,7 @@
     "\n",
     "# Posterior emissions\n",
     "posterior_ds = get_posterior_emissions(prior_ds, scale_ds)\n",
-    "posterior = posterior_ds[\"EmisCH4_Total\"].isel(time=0)"
+    "posterior = posterior_ds[\"EmisCH4_Total\"]"
    ]
   },
   {
@@ -319,7 +319,7 @@
     "emission_types = {}\n",
     "for sector in sector_list:\n",
     "    emission = sum_total_emissions(\n",
-    "        posterior_ds[sector].isel(time=0), areas, mask\n",
+    "        posterior_ds[sector], areas, mask\n",
     "    )\n",
     "    print(f\"{sector} = {emission} Tg/yr\")\n",
     "    if emission > 0:\n",


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG
 
### Describe the update
This addresses #237. 
When a non-kalman-filter inversion runs more than one month, HEMCO emissions files are generated for each month. In places like the preview and visualization notebook, only the first month of emissions are used. So if you ran a 1 year inversion, the emissions reported are just for January.

This update computes the daily emissions and updates them daily during the jacobian and posterior simulations.

I also add logic to compute the time averaged emissions for the inversion period for python scripts.