### PR TITLE
only apply scale factors to emission data variables

### DIFF
--- a/src/components/posterior_component/update_prior_emis.py
+++ b/src/components/posterior_component/update_prior_emis.py
@@ -29,7 +29,10 @@ def get_posterior_emissions(prior, scale):
     prior["EmisCH4_Total"] = prior["EmisCH4_Total"] - prior_soil_sink
     
     # scale the prior emissions for all sectors using the scale factors
-    posterior = prior * scale["ScaleFactor"]
+    posterior = prior.copy()
+    for ds_var in list(prior.keys()):
+        if "EmisCH4" in ds_var:
+            posterior[ds_var] = prior[ds_var] * scale["ScaleFactor"]
     
     # But reset the soil sink to the original value
     posterior["EmisCH4_SoilAbsorb"] = prior_soil_sink

--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -384,6 +384,9 @@ def get_posterior_emissions(prior, scale):
         posterior : xarray dataset
             posterior emissions
     """
+    # keep attributes of data even when arithmetic operations applied
+    xr.set_options(keep_attrs=True)
+    
     # we do not optimize soil absorbtion in the inversion. This 
     # means that we need to keep the soil sink constant and properly 
     # account for it in the posterior emissions calculation.
@@ -396,7 +399,10 @@ def get_posterior_emissions(prior, scale):
     prior["EmisCH4_Total"] = prior["EmisCH4_Total"] - prior_soil_sink
     
     # scale the prior emissions for all sectors using the scale factors
-    posterior = prior * scale["ScaleFactor"]
+    posterior = prior.copy()
+    for ds_var in list(prior.keys()):
+        if "EmisCH4" in ds_var:
+            posterior[ds_var] = prior[ds_var] * scale["ScaleFactor"]
     
     # But reset the soil sink to the original value
     posterior["EmisCH4_SoilAbsorb"] = prior_soil_sink


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
This fixes a bug where all data variables were multiplied by scale factors when calculating the posterior. Notably, the AREA data variable was also multiplied. If these areas were then used to calculate the total emissions, the calculation would be wrong. 