### PR TITLE
Restore use of archived HEMCO standalone output for generating state vectors

### DIFF
--- a/src/components/statevector_component/statevector.sh
+++ b/src/components/statevector_component/statevector.sh
@@ -16,20 +16,16 @@ create_statevector() {
     else
         LandCoverFile="${DataPath}/GEOS_${gridDir}/${metDir}/${constYr}/01/${Met}.${constYr}0101.CN.${gridFile}.${LandCoverFileExtension}"
     fi
-
-    # First generate the prior emissions if not available yet
-    if [[ ! -d ${RunDirs}/prior_run/OutputDir ]]; then
-        printf "\nPrior Dir not detected. Running HEMCO for prior emissions as a prerequisite for creating the state vector.\n"
-        run_prior
-    fi
     
-    # Use prior emissions output
-    HemcoDiagFile="${RunDirs}/prior_run/OutputDir/HEMCO_sa_diagnostics.${StartDate}0000.nc"
+    # Use archived HEMCO standalone emissions output
+    HemcoDiagFile="${DataPath}/HEMCO/CH4/v2024-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.${gridFile}.2023.nc"
 	
     if "$isAWS"; then
         # Download land cover and HEMCO diagnostics files
         s3_lc_path="s3://gcgrid/GEOS_${gridDir}/${metDir}/${constYr}/01/${Met}.${constYr}0101.CN.${gridFile}.${RegionID}.${LandCoverFileExtension}"
         aws s3 cp --no-sign-request ${s3_lc_path} ${LandCoverFile}
+        s3_hd_path="s3://gcgrid/HEMCO/CH4/v2024-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.${gridFile}.2023.nc"
+        aws s3 cp --no-sign-request ${s3_hd_path} ${HemcoDiagFile}
     fi
 
     # Output path and filename for state vector file
@@ -53,12 +49,6 @@ create_statevector() {
 #   reduce_dimension
 reduce_dimension() {
     printf "\n=== REDUCING DIMENSION OF STATE VECTOR FILE ===\n"
-
-    # First generate the prior emissions if not available yet
-    if [[ ! -d ${RunDirs}/prior_run/OutputDir ]]; then
-        printf "\nPrior Dir not detected. Running HEMCO for prior emissions as a prerequisite for reducing dimension of state vector.\n"
-        run_prior
-    fi
 
     # set input variables
     state_vector_path=${RunDirs}/StateVector.nc

--- a/src/notebooks/statevector_from_shapefile.ipynb
+++ b/src/notebooks/statevector_from_shapefile.ipynb
@@ -46,7 +46,7 @@
     "import warnings; warnings.filterwarnings(action='ignore')\n",
     "sys.path.append('../../')\n",
     "from src.utilities.make_state_vector_file import cluster_buffer_elements\n",
-    "from src.utilities.utils import download_landcover_files\n",
+    "from src.utilities.utils import download_landcover_files, download_hemcodiags_files\n",
     "%matplotlib inline"
    ]
   },
@@ -84,6 +84,7 @@
    "source": [
     "# Download landcover files from s3 if not already present\n",
     "download_landcover_files(config)\n",
+    "download_hemcodiags_files(config)"
    ]
   },
   {
@@ -348,8 +349,8 @@
     "gridDir = f'{config[\"Res\"]}_{config[\"RegionID\"]}'\n",
     "land_cover_file = f'{met_token1}.{constYr}0101.CN.{gridRes}.{config[\"RegionID\"]}.nc'\n",
     "land_cover_pth = f'/home/ubuntu/ExtData/GEOS_{gridDir}/{met_token2}/{constYr}/01/{land_cover_file}'\n",
-    "hemco_diag_file = f'HEMCO_sa_diagnostics.{StartDate}0000.nc'\n",
-    "hemco_diag_pth = f'{RunDirs}/prior_run/OutputDir/{hemco_diag_file}'"
+    "hemco_diag_file = f'HEMCO_sa_diagnostics.{gridRes}.2023.nc'\n",
+    "hemco_diag_pth = f'/home/ubuntu/ExtData/HEMCO/CH4/v2024-07/HEMCO_SA_Output/{hemco_diag_file}'"
    ]
   },
   {

--- a/src/utilities/make_state_vector_file.py
+++ b/src/utilities/make_state_vector_file.py
@@ -158,14 +158,6 @@ def make_state_vector_file(
     lc = xr.load_dataset(land_cover_pth)
     hd = xr.load_dataset(hemco_diag_pth)
 
-    # Require hemco diags on same global grid as land cover map
-    # TODO remove this offset once the HEMCO standalone files 
-    # are regenerated with recent bugfix that corrects the offset
-    if config["Res"] == "0.25x0.3125":
-        hd["lon"] = hd["lon"] - 0.03125
-    elif config["Res"] == "0.5x0.625":
-        hd["lon"] = hd["lon"] - 0.0625
-
     # Select / group fields together
     lc = (lc["FRLAKE"] + lc["FRLAND"] + lc["FRLANDIC"]).drop_vars("time").squeeze()
     hd = (hd["EmisCH4_Oil"] + hd["EmisCH4_Gas"]).drop_vars("time").squeeze()

--- a/src/utilities/utils.py
+++ b/src/utilities/utils.py
@@ -46,3 +46,33 @@ def download_landcover_files(config):
         else results
     )
     print(output)
+
+
+def download_hemcodiags_files(config):
+    """
+    Download global hemco diagnostics files from s3 given the config file
+    """
+    DataPath = "/home/ubuntu/ExtData"
+
+    if config["Res"] == "4.0x5.0":
+        gridFile = "4x5"
+    elif config["Res"] == "2.0x2.5":
+        gridFile = "2x25"
+    elif config["Res"] == "0.5x0.625":
+        gridFile = "05x0625"
+    elif config["Res"] == "0.25x0.3125":
+        gridFile = "025x03125"
+
+    HemcoDiagFile = f"{DataPath}/HEMCO/CH4/v2024-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.{gridFile}.2023.nc"
+    s3_hd_path = f"s3://gcgrid/HEMCO/CH4/v2024-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.{gridFile}.2023.nc"
+
+    # run the aws command to download the files
+    command = f"aws s3 cp --no-sign-request {s3_hd_path} {HemcoDiagFile}"
+    results = subprocess.run(command.split(), capture_output=True, text=True)
+
+    output = (
+        "Successfully downloaded hemco diags files"
+        if results.returncode == 0
+        else results
+    )
+    print(output)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

Updates in https://github.com/geoschem/integrated_methane_inversion/pull/245 created a circular depenedency between the IMI preview and the prior simulation as documented in https://github.com/geoschem/integrated_methane_inversion/issues/253. This can be avoided by restoring the use of archived HEMCO standalone output in the generation of the state vector. Use of the HEMCO prior emissions have been removed from the state vector scripts.

New HEMCO standalone simulations have been performed archiving annual mean emissions for 2023 for 0.25x0.3125, 0.5x0.625, 2x2.5, and 4x5 degree global grids. These can be found in the GEOS-Chem data path HEMCO/CH4/v2024-07/HEMCO_SA_Output.