### PR TITLE
Add Period CSV file options to default config.yml file and set MakePeriodsCSV to false by default

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -45,6 +45,8 @@ LatMax: 33
 KalmanMode: false
 UpdateFreqDays: 7
 NudgeFactor: 0.1
+MakePeriodsCSV: false
+CustomPeriodsCSV: "/path/to/periods.csv"
 
 ## State vector
 CreateAutomaticRectilinearStateVectorFile: true

--- a/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
@@ -45,7 +45,7 @@ LatMax: 90
 KalmanMode: false
 UpdateFreqDays: 7
 NudgeFactor: 0.1
-MakePeriodsCSV: true
+MakePeriodsCSV: false
 CustomPeriodsCSV: "/path/to/periods.csv"
 
 ## State vector

--- a/envs/Harvard-Cannon/config.harvard-cannon.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.yml
@@ -45,7 +45,7 @@ LatMax: 33
 KalmanMode: false
 UpdateFreqDays: 7
 NudgeFactor: 0.1
-MakePeriodsCSV: true
+MakePeriodsCSV: false
 CustomPeriodsCSV: "/path/to/periods.csv"
 
 ## State vector


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The MakePeriodCSV option was missing from the default config.yml file resulting in error messages in preview.sh. We now also set this option to false by default in all config files (including the Harvard-specific ones) since KalmanMode is also set to false by default.