### PR TITLE
bugfix for printing posterior emissions

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -48,7 +48,7 @@ LatMax: 33
 KalmanMode: false
 UpdateFreqDays: 7
 NudgeFactor: 0.1
-MakePeriodsCSV: false
+MakePeriodsCSV: true
 CustomPeriodsCSV: "/path/to/periods.csv"
 
 ## State vector

--- a/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
@@ -48,7 +48,7 @@ LatMax: 90
 KalmanMode: false
 UpdateFreqDays: 7
 NudgeFactor: 0.1
-MakePeriodsCSV: false
+MakePeriodsCSV: true
 CustomPeriodsCSV: "/path/to/periods.csv"
 
 ## State vector

--- a/envs/Harvard-Cannon/config.harvard-cannon.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.yml
@@ -48,7 +48,7 @@ LatMax: 33
 KalmanMode: false
 UpdateFreqDays: 7
 NudgeFactor: 0.1
-MakePeriodsCSV: false
+MakePeriodsCSV: true
 CustomPeriodsCSV: "/path/to/periods.csv"
 
 ## State vector

--- a/resources/containers/al2/container_config.yml
+++ b/resources/containers/al2/container_config.yml
@@ -48,7 +48,7 @@ LatMax: 33
 KalmanMode: false
 UpdateFreqDays: 7
 NudgeFactor: 0.1
-MakePeriodsCSV: false
+MakePeriodsCSV: true
 CustomPeriodsCSV: "/path/to/periods.csv"
 
 ## State vector

--- a/src/components/kalman_component/print_posterior_emissions.py
+++ b/src/components/kalman_component/print_posterior_emissions.py
@@ -42,7 +42,7 @@ def print_posterior_emissions(config_path, period_number, base_directory):
     hemco_emis = hemco_diags
     posterior_sf = xr.load_dataset(post_sf_path)
     posterior_emis_ds = get_posterior_emissions(hemco_emis, posterior_sf)
-    posterior_emis = posterior_emis_ds["EmisCH4_Total"].isel(time=0, drop=True)
+    posterior_emis = posterior_emis_ds["EmisCH4_Total"]
     total_emis = sum_total_emissions(posterior_emis, areas, mask)
 
     # Print

--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -464,7 +464,7 @@ def get_period_mean_emissions(prior_cache_path, period, periods_csv_path):
     Calculate the mean emissions for the specified kalman period.
     """
     period_df = pd.read_csv(periods_csv_path)
-    period_df = period_df[period_df['period_number'] == period]
+    period_df = period_df[period_df['period_number'] == int(period)]
     period_df.reset_index(drop=True, inplace=True)
     start_date = str(period_df.loc[0,"Starts"])
     end_date = str(period_df.loc[0,"Ends"])


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Describe the update

* Arguments are passed as a string by default, so the filtering turned `period_df` into an empty DataFrame.
* `posterior_emis_ds` will never have a time dimension, so it can't be selected.

I tested this with this script. It feels like `MakePeriodsCSV` should default to `true` but maybe the IMI isn't set up to handle that based on #256 (unless #260 fixes that).
```
#!/bin/bash

git clone https://github.com/geoschem/integrated_methane_inversion.git
cd integrated_methane_inversion
git checkout 8b5bf2a # bugfix/kf-printing
sed -i -e "s|Test_IMI_Permian|Test_IMI_Permian_KF|g" \
    -e "s|BlendedTROPOMI: false|BlendedTROPOMI: true|g" \
    -e "s|KalmanMode: false|KalmanMode: true|g" \
    -e "s|MakePeriodsCSV: false|MakePeriodsCSV: true|g" \
    -e "s|20180508|20180522|g" \
    -e "s|SetupSpinupRun: false|SetupSpinupRun: true|g" \
    -e "s|SetupJacobianRuns: false|SetupJacobianRuns: true|g" \
    -e "s|SetupInversion: false|SetupInversion: true|g" \
    -e "s|SetupPosteriorRun: false|SetupPosteriorRun: true|g" \
    -e "s|DoSpinup: false|DoSpinup: true|g" \
    -e "s|^DoJacobian: false|DoJacobian: true|g" \
    -e "s|DoInversion: false|DoInversion: true|g" \
    -e "s|DoPosterior: false|DoPosterior: true|g" \
    -e "s|/tropomi|/blended|g" envs/Harvard-Cannon/config.harvard-cannon.yml
sbatch -p huce_cascade -t 2-00:00 run_imi.sh envs/Harvard-Cannon/config.harvard-cannon.yml
```