### PR TITLE
default to End for DiagnFreq

### DIFF
--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -106,13 +106,8 @@ setup_template() {
         sed -i -e "s:\$RES:\$RES.${RegionID}:g" HEMCO_Config.rc.gmao_metfields
     fi
 
-    # Determine length of inversion period in days
-    InvPeriodLength=$(( ( $(date -d ${EndDate} "+%s") - $(date -d ${StartDate} "+%s") ) / 86400))
-
-    # If inversion period is < 32 days, use End diagnostic output frequency
-    if (( ${InvPeriodLength} < 32 )) || $KalmanMode; then
-        sed -i -e "s|DiagnFreq:                   Monthly|DiagnFreq:                   End|g" HEMCO_Config.rc
-    fi
+    # By default, only output emissions at the end of the simulation
+    sed -i -e "s|DiagnFreq:                   Monthly|DiagnFreq:                   End|g" HEMCO_Config.rc
 
     # Modify path to BC files
     sed -i -e "s:\$ROOT/SAMPLE_BCs/v2021-07/CH4:${fullBCpath}:g" HEMCO_Config.rc


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard

### Describe the update

In non-Kalman filter inversion longer than 32 days (@eastjames @sarahhancock etc.), DiagnFreq was being left as Monthly meaning it wouldn't be overwritten to daily here:
https://github.com/geoschem/integrated_methane_inversion/blob/235ff1443a482b72c4831aab47bfec0abc319820/src/components/prior_component/prior.sh#L75

This means the HEMCO standalone wasn't writing daily files and thus the averaging etc. is probably off by a factor of the number of days in each month.