### PR TITLE
Bugfix/new-env

### DIFF
--- a/src/inversion_scripts/invert.py
+++ b/src/inversion_scripts/invert.py
@@ -322,13 +322,14 @@ if __name__ == "__main__":
 
     # Save results
     dataset = Dataset(output_path, "w", format="NETCDF4_CLASSIC")
-    nvar = dataset.createDimension("nvar", n_elements)
-    nc_KTinvSoK = dataset.createVariable("KTinvSoK", np.float32, ("nvar", "nvar"))
-    nc_KTinvSoyKxA = dataset.createVariable("KTinvSoyKxA", np.float32, ("nvar"))
-    nc_ratio = dataset.createVariable("ratio", np.float32, ("nvar"))
-    nc_xhat = dataset.createVariable("xhat", np.float32, ("nvar"))
-    nc_S_post = dataset.createVariable("S_post", np.float32, ("nvar", "nvar"))
-    nc_A = dataset.createVariable("A", np.float32, ("nvar", "nvar"))
+    nvar1 = dataset.createDimension("nvar1", n_elements)
+    nvar2 = dataset.createDimension("nvar2", n_elements)
+    nc_KTinvSoK = dataset.createVariable("KTinvSoK", np.float32, ("nvar1", "nvar2"))
+    nc_KTinvSoyKxA = dataset.createVariable("KTinvSoyKxA", np.float32, ("nvar1"))
+    nc_ratio = dataset.createVariable("ratio", np.float32, ("nvar1"))
+    nc_xhat = dataset.createVariable("xhat", np.float32, ("nvar1"))
+    nc_S_post = dataset.createVariable("S_post", np.float32, ("nvar1", "nvar2"))
+    nc_A = dataset.createVariable("A", np.float32, ("nvar1", "nvar2"))
     nc_KTinvSoK[:, :] = KTinvSoK
     nc_KTinvSoyKxA[:] = KTinvSoyKxA
     nc_ratio[:] = ratio

--- a/src/inversion_scripts/lognormal_invert.py
+++ b/src/inversion_scripts/lognormal_invert.py
@@ -286,12 +286,13 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
 
         # Save (ungridded) inversion results
         dataset = Dataset(results_save_path, "w", format="NETCDF4_CLASSIC")
-        dataset.createDimension("nvar", num_sv_elems)
+        dataset.createDimension("nvar1", num_sv_elems)
+        dataset.createDimension("nvar2", num_sv_elems)
         dataset.createDimension("float", 1)
-        nc_xn = dataset.createVariable("xhat", np.float32, ("nvar"))
-        nc_lnxn = dataset.createVariable("lnxn", np.float32, ("nvar"))
-        nc_lnS_post = dataset.createVariable("S_post", np.float32, ("nvar", "nvar"))
-        nc_A = dataset.createVariable("A", np.float32, ("nvar", "nvar"))
+        nc_xn = dataset.createVariable("xhat", np.float32, ("nvar1"))
+        nc_lnxn = dataset.createVariable("lnxn", np.float32, ("nvar1"))
+        nc_lnS_post = dataset.createVariable("S_post", np.float32, ("nvar1", "nvar2"))
+        nc_A = dataset.createVariable("A", np.float32, ("nvar1", "nvar2"))
         nc_dofs = dataset.createVariable("DOFS", np.float32, ("float",))
         nc_Ja = dataset.createVariable("Ja", np.float32, ("float",))
         nc_xn[:] = xnmean.flatten()

--- a/src/inversion_scripts/make_gridded_posterior.py
+++ b/src/inversion_scripts/make_gridded_posterior.py
@@ -60,6 +60,9 @@ def make_gridded_posterior(posterior_SF_path, state_vector_path, save_path):
     gridded_S_post = do_gridding(S_post, statevector)
     gridded_A = do_gridding(A, statevector)
 
+    # Fill nan in SF with 1 to prevent GEOS-Chem error
+    gridded_SF = gridded_SF.fillna(1)
+
     # Create dataset
     lat = gridded_SF["lat"].values
     lon = gridded_SF["lon"].values

--- a/src/inversion_scripts/operators/TROPOMI_operator.py
+++ b/src/inversion_scripts/operators/TROPOMI_operator.py
@@ -529,7 +529,12 @@ def read_tropomi(filename):
         with xr.open_dataset(filename, group="PRODUCT/SUPPORT_DATA/INPUT_DATA") as tropomi_data:
             dat["methane_profile_apriori"] = tropomi_data["methane_profile_apriori"].values[0, :, :, ::-1]  # mol m-2
             dat["dry_air_subcolumns"] = tropomi_data["dry_air_subcolumns"].values[0, :, :, ::-1]  # mol m-2
-            dat["surface_classification"] = (tropomi_data["surface_classification"].values[0, :, :].astype("uint8") & 0x03).astype(int)
+            sc = tropomi_data["surface_classification"].values[0, :, :]
+            nan_mask = np.isnan(sc)
+            sc_no_nans = np.nan_to_num(sc, nan=0)
+            sc = (sc_no_nans.astype("uint8") & 0x03).astype(int)
+            sc[nan_mask] = np.nan
+            dat["surface_classification"] = sc
 
             # Also get pressure interval and surface pressure for use below
             pressure_interval = (tropomi_data["pressure_interval"].values[0, :, :] / 100)  # Pa -> hPa

--- a/src/inversion_scripts/operators/TROPOMI_operator.py
+++ b/src/inversion_scripts/operators/TROPOMI_operator.py
@@ -533,8 +533,12 @@ def read_tropomi(filename):
             nan_mask = np.isnan(sc)
             sc_no_nans = np.nan_to_num(sc, nan=0)
             sc = (sc_no_nans.astype("uint8") & 0x03).astype(int)
-            sc[nan_mask] = np.nan
+            # Surface classification values of NaN will be filtered out
+            # due to a low QA value. We can make sure by setting them to 5
+            # and making sure nothing outside of [0,1,2,3] makes it through.
+            sc[nan_mask] = 5
             dat["surface_classification"] = sc
+            sc = ds["surface_classification"].values[0,:,:]
 
             # Also get pressure interval and surface pressure for use below
             pressure_interval = (tropomi_data["pressure_interval"].values[0, :, :] / 100)  # Pa -> hPa

--- a/src/inversion_scripts/operators/TROPOMI_operator.py
+++ b/src/inversion_scripts/operators/TROPOMI_operator.py
@@ -529,16 +529,16 @@ def read_tropomi(filename):
         with xr.open_dataset(filename, group="PRODUCT/SUPPORT_DATA/INPUT_DATA") as tropomi_data:
             dat["methane_profile_apriori"] = tropomi_data["methane_profile_apriori"].values[0, :, :, ::-1]  # mol m-2
             dat["dry_air_subcolumns"] = tropomi_data["dry_air_subcolumns"].values[0, :, :, ::-1]  # mol m-2
+
+            # Surface classification values of NaN will be filtered out
+            # due to a low QA value. We can make sure by setting them to 5
+            # and making sure nothing outside of [0,1,2,3] makes it through.
             sc = tropomi_data["surface_classification"].values[0, :, :]
             nan_mask = np.isnan(sc)
             sc_no_nans = np.nan_to_num(sc, nan=0)
             sc = (sc_no_nans.astype("uint8") & 0x03).astype(int)
-            # Surface classification values of NaN will be filtered out
-            # due to a low QA value. We can make sure by setting them to 5
-            # and making sure nothing outside of [0,1,2,3] makes it through.
             sc[nan_mask] = 5
             dat["surface_classification"] = sc
-            sc = ds["surface_classification"].values[0,:,:]
 
             # Also get pressure interval and surface pressure for use below
             pressure_interval = (tropomi_data["pressure_interval"].values[0, :, :] / 100)  # Pa -> hPa

--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -302,9 +302,6 @@ def filter_tropomi(tropomi_data, xlim, ylim, startdate, enddate, use_water_obs=F
               & (tropomi_data["longitude_bounds"].ptp(axis=2) < 100)
               & (tropomi_data["latitude"] > -60))
 
-    # Make sure the surface classification flags have been made correctly
-    assert np.max(tropomi_data["surface_classification"][valid_idx]) <= 3
-
     if use_water_obs:
         return np.where(valid_idx)
     else:
@@ -333,9 +330,6 @@ def filter_blended(blended_data, xlim, ylim, startdate, enddate, use_water_obs=F
               & (blended_data["longitude_bounds"].ptp(axis=2) < 100)
               & ~((blended_data["surface_classification"] == 3) | ((blended_data["surface_classification"] == 2) & (blended_data["chi_square_SWIR"][:] > 20000)))
               & (blended_data["latitude"] > -60))
-
-    # Make sure the surface classification flags have been made correctly
-    assert np.max(tropomi_data["surface_classification"][valid_idx]) <= 3
     
     if use_water_obs:
         return np.where(valid_idx)

--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -302,6 +302,9 @@ def filter_tropomi(tropomi_data, xlim, ylim, startdate, enddate, use_water_obs=F
               & (tropomi_data["longitude_bounds"].ptp(axis=2) < 100)
               & (tropomi_data["latitude"] > -60))
 
+    # Make sure the surface classification flags have been made correctly
+    assert np.max(tropomi_data["surface_classification"][valid_idx]) <= 3
+
     if use_water_obs:
         return np.where(valid_idx)
     else:
@@ -330,6 +333,9 @@ def filter_blended(blended_data, xlim, ylim, startdate, enddate, use_water_obs=F
               & (blended_data["longitude_bounds"].ptp(axis=2) < 100)
               & ~((blended_data["surface_classification"] == 3) | ((blended_data["surface_classification"] == 2) & (blended_data["chi_square_SWIR"][:] > 20000)))
               & (blended_data["latitude"] > -60))
+
+    # Make sure the surface classification flags have been made correctly
+    assert np.max(tropomi_data["surface_classification"][valid_idx]) <= 3
     
     if use_water_obs:
         return np.where(valid_idx)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Describe the update

With the new conda environment, there are some new warnings in the IMI test case. One is for duplicate dimensions (`nvar`) which is fixed here. 

The other is for NaNs being passed to the `uint8` casting, which is also fixed here. This is with respect to the `surface_classification` variable in TROPOMI files. There are no NaNs in the blended files because QA flag filtering has already occurred.

The posterior was also failing with `Infinity in DO_CLOUD_CONVECTION!` which was due to NaNs in the scale factors. These NaNs are set to 1.