### PR TITLE
bugfix/handle-operator-updates-in-bcs

### DIFF
--- a/src/write_BCs/write_boundary_conditions.py
+++ b/src/write_BCs/write_boundary_conditions.py
@@ -50,7 +50,8 @@ def apply_tropomi_operator_to_one_tropomi_file(filename):
         ylim = [-90, 90],
         gc_cache = os.path.join(config["workDir"], "gc_run", "OutputDir"),
         build_jacobian = False, # Not relevant
-        sensi_cache = False) # Not relevant
+        period_i = False, # Not relevant
+        config = False) # Not relevant
     
     return result["obs_GC"],filename
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Describe the update

Updating the boundary condition generation scripts. I regenerated BCs for 20180401-20240229 and found them to be zero-diff w.r.t. v2024-06 (with new environment + some commits that changed the operator).