### PR TITLE
Fix and improve IMI Preview DOFS calculation

### DIFF
--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -599,8 +599,8 @@ def estimate_averaging_kernel(
     def process(i):
         mask = state_vector_labels == i
 
-        # Following eqn. 11 of Nesser et al., 2021 we increase the mask 
-        # size by adding concentric rings to mimic transport/diffusion 
+        # Following eqn. 11 of Nesser et al., 2021 we increase the mask
+        # size by adding concentric rings to mimic transport/diffusion
         # when counting observations. We use 2 concentric rings based on
         # empirical evidence -- Nesser et al used 3.
         structure = np.ones((5, 5))
@@ -716,11 +716,10 @@ def estimate_averaging_kernel(
     # a is set to 0 where m_superi is 0
     m_superi = np.array(m_superi)
     k = alpha * (Mair * L * g / (Mch4 * U * p))
-    a = np.where(
-        np.equal(m_superi, 0),
-        float(0),
-        sA**2 / (sA**2 + (s_superO / k) ** 2 / (m_superi)),
-    )
+    a = sA**2 / (sA**2 + (s_superO / k) ** 2 / (m_superi))
+    
+    # Places with 0 superobs should be 0
+    a = np.where(np.equal(m_superi, 0), float(0), a)
 
     outstring3 = f"k = {np.round(k,5)} kg-1 m2 s"
     outstring4 = f"a = {np.round(a,5)} \n"

--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -736,7 +736,7 @@ def estimate_averaging_kernel(
         outstrings = (
             f"##{outstring1}\n" + f"##{outstring3}\n" + f"##{outstring4}\n" + outstring5
         )
-        return a, df, num_days, prior, outstrings
+        return a, df.drop(columns=["time"]), num_days, prior, outstrings
     else:
         return a
 

--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -36,6 +36,7 @@ from src.inversion_scripts.operators.TROPOMI_operator import (
     read_blended,
 )
 
+warnings.filterwarnings("ignore", message="PROJ: proj_create_from_database")
 warnings.filterwarnings("ignore", category=FutureWarning)
 
 

--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -22,7 +22,6 @@ from joblib import Parallel, delayed
 from src.inversion_scripts.point_sources import get_point_source_coordinates
 from src.inversion_scripts.utils import (
     sum_total_emissions,
-    count_obs_in_mask,
     plot_field,
     filter_tropomi,
     filter_blended,
@@ -142,13 +141,6 @@ def imi_preview(
         kf_index=None,
     )
     mask = state_vector_labels <= last_ROI_element
-
-    # Count the number of observations in the region of interest
-    num_obs = count_obs_in_mask(mask, df)
-    if num_obs < 1:
-        sys.exit("Error: No observations found in region of interest")
-    outstring2 = f"Found {num_obs} observations in the region of interest"
-    print("\n" + outstring2)
 
     # ----------------------------------
     # Estimate dollar cost
@@ -641,6 +633,7 @@ def estimate_averaging_kernel(
     if np.sum(num_obs) < 1:
         sys.exit("Error: No observations found in region of interest")
     outstring2 = f"Found {np.sum(num_obs)} observations in the region of interest"
+    print("\n" + outstring2)
 
     # ----------------------------------
     # Estimate information content

--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -98,6 +98,7 @@ def get_TROPOMI_data(
         tropomi_data["lon"].append(TROPOMI["longitude"][lat_idx, lon_idx])
         tropomi_data["xch4"].append(TROPOMI["methane"][lat_idx, lon_idx])
         tropomi_data["swir_albedo"].append(TROPOMI["swir_albedo"][lat_idx, lon_idx])
+        tropomi_data['time'].append(TROPOMI['time'][lat_idx, lon_idx])
 
     return tropomi_data
 
@@ -510,6 +511,7 @@ def estimate_averaging_kernel(
     lon = []
     xch4 = []
     albedo = []
+    trtime = []
 
     # Read in and filter tropomi observations (uses parallel processing)
     observation_dicts = Parallel(n_jobs=-1)(
@@ -527,17 +529,17 @@ def estimate_averaging_kernel(
     # Remove any problematic observation dicts (eg. corrupted data file)
     observation_dicts = list(filter(None, observation_dicts))
 
-    for dict in observation_dicts:
-        lat.extend(dict["lat"])
-        lon.extend(dict["lon"])
-        xch4.extend(dict["xch4"])
-        albedo.extend(dict["swir_albedo"])
+    for obs_dict in observation_dicts:
+        lat.extend(obs_dict["lat"])
+        lon.extend(obs_dict["lon"])
+        xch4.extend(obs_dict["xch4"])
+        albedo.extend(obs_dict["swir_albedo"])
 
     # Assemble in dataframe
     df = pd.DataFrame()
     df["lat"] = lat
     df["lon"] = lon
-    df["count"] = np.ones(len(lat))
+    df["obs_count"] = np.ones(len(lat))
     df["swir_albedo"] = albedo
     df["xch4"] = xch4
 
@@ -561,7 +563,27 @@ def estimate_averaging_kernel(
         lon_step = 5.0
 
     # bin observations into gridcells and map onto statevector
-    observation_counts = add_observation_counts(df, state_vector, lat_step, lon_step)
+
+    to_lon = lambda x: np.floor(x / lon_step) * lon_step
+    to_lat = lambda x: np.floor(x / lat_step) * lat_step
+
+    df_super = df.rename(columns={"lon": "old_lon", "lat": "old_lat"})
+
+    df_super["lat"] = to_lat(df_super.old_lat)
+    df_super["lon"] = to_lon(df_super.old_lon)
+    groups = df_super[['obs_count', 'lat', 'lon']].groupby(['lat', 'lon'])
+    tgroups = df_super[['obs_count','lat','lon','time']].groupby(['lat', 'lon', df_super.time.dt.date])
+
+    observation_counts = xr.merge([
+        groups.count().to_xarray(),
+        state_vector
+    ])
+
+    daily_observation_counts = xr.merge([
+        tgroups.count().to_xarray(),
+        state_vector
+    ])
+    daily_observation_counts.values = np.where(np.isnan(daily_observation_counts),0,1)
 
     # parallel processing function
     def process(i):
@@ -573,8 +595,10 @@ def estimate_averaging_kernel(
         # append the calculated length scale of element
         L_temp = L_native * size_temp
         # append the number of obs in each element
-        num_obs_temp = np.nansum(observation_counts["count"].where(mask).values)
-        return emissions_temp, L_temp, size_temp, num_obs_temp
+        num_obs_temp = np.nansum(observation_counts.where(mask).values)
+        # append the number of successful obs days
+        n_success_obs_days = np.nansum(daily_observation_counts.where(mask)).item()
+        return emissions_temp, L_temp, size_temp, num_obs_temp, n_success_obs_days
 
     # in parallel, create lists of emissions, number of observations,
     # and rough length scale for each cluster element in ROI
@@ -583,7 +607,7 @@ def estimate_averaging_kernel(
     )
 
     # unpack list of tuples into individual lists
-    emissions, L, num_native_elements, num_obs = [list(item) for item in zip(*result)]
+    emissions, L, num_native_elements, num_obs, m_superi = [list(item) for item in zip(*result)]
 
     if np.sum(num_obs) < 1:
         sys.exit("Error: No observations found in region of interest")
@@ -657,11 +681,19 @@ def estimate_averaging_kernel(
     ]
     s_superO = np.array(s_superO_p) * 1e-9  # convert to ppb
 
+    # TODO: add eqn number from Estrada et al. 2024 once published
     # Averaging kernel sensitivity for each grid element
-    # Note: m is the number of superobservations (just days if native),
-    # but if clustered it is days * num_native_elements
+    # Note: m_superi is the number of superobservations,
+    # defined as sum of days in each grid cell with >0 successful obs
+    # in the state vector element
+    # a set to 0 where m_superi is 0
+    m_superi = np.array(m_superi)
     k = alpha * (Mair * L * g / (Mch4 * U * p))
-    a = sA**2 / (sA**2 + (s_superO / k) ** 2 / (m * num_native_elements))
+    a = np.where(
+        np.equal(m_superi, 0),
+        float(0),
+        sA**2 / (sA**2 + (s_superO / k) ** 2 / (m_superi))
+    )
 
     outstring3 = f"k = {np.round(k,5)} kg-1 m2 s"
     outstring4 = f"a = {np.round(a,5)} \n"
@@ -681,25 +713,6 @@ def estimate_averaging_kernel(
         return a, df, num_days, prior, outstrings
     else:
         return a
-
-
-def add_observation_counts(df, state_vector, lat_step, lon_step):
-    """
-    Given arbitrary observation coordinates in a pandas df, group
-    them by gridcell and return the number of observations mapped
-    onto the statevector dataset
-    """
-    to_lon = lambda x: np.floor(x / lon_step) * lon_step
-    to_lat = lambda x: np.floor(x / lat_step) * lat_step
-
-    df = df.rename(columns={"lon": "old_lon", "lat": "old_lat"})
-
-    df["lat"] = to_lat(df.old_lat)
-    df["lon"] = to_lon(df.old_lon)
-    groups = df.groupby(["lat", "lon"])
-
-    counts_ds = groups.sum().to_xarray().drop_vars(["old_lat", "old_lon"])
-    return xr.merge([counts_ds, state_vector])
 
 
 if __name__ == "__main__":

--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -200,7 +200,6 @@ def imi_preview(
 
     # Write preview diagnostics to text file
     outputtextfile = open(os.path.join(preview_dir, "preview_diagnostics.txt"), "w+")
-    outputtextfile.write("##" + outstring2 + "\n")
     outputtextfile.write("##" + outstring6 + "\n")
     outputtextfile.write("##" + outstring7 + "\n")
     outputtextfile.write(outstrings)
@@ -710,7 +709,7 @@ def estimate_averaging_kernel(
     m_superi = np.array(m_superi)
     k = alpha * (Mair * L * g / (Mch4 * U * p))
     a = sA**2 / (sA**2 + (s_superO / k) ** 2 / (m_superi))
-    
+
     # Places with 0 superobs should be 0
     a = np.where(np.equal(m_superi, 0), float(0), a)
 
@@ -727,7 +726,11 @@ def estimate_averaging_kernel(
 
     if preview:
         outstrings = (
-            f"##{outstring1}\n" + f"##{outstring3}\n" + f"##{outstring4}\n" + outstring5
+            f"##{outstring1}\n"
+            + f"##{outstring2}\n"
+            + f"##{outstring3}\n"
+            + f"##{outstring4}\n"
+            + outstring5
         )
         return a, df.drop(columns=["time"]), num_days, prior, outstrings
     else:

--- a/src/notebooks/statevector_from_shapefile.ipynb
+++ b/src/notebooks/statevector_from_shapefile.ipynb
@@ -45,6 +45,7 @@
     "import matplotlib.pyplot as plt\n",
     "import yaml\n",
     "import warnings; warnings.filterwarnings(action='ignore')\n",
+    "warnings.filterwarnings(\"ignore\", message=\"PROJ: proj_create_from_database\")\n",
     "sys.path.append('../../')\n",
     "from src.utilities.make_state_vector_file import cluster_buffer_elements\n",
     "from src.utilities.utils import download_landcover_files, download_hemcodiags_files\n",

--- a/src/notebooks/statevector_from_shapefile.ipynb
+++ b/src/notebooks/statevector_from_shapefile.ipynb
@@ -45,7 +45,6 @@
     "import matplotlib.pyplot as plt\n",
     "import yaml\n",
     "import warnings; warnings.filterwarnings(action='ignore')\n",
-    "warnings.filterwarnings(\"ignore\", message=\"PROJ: proj_create_from_database\")\n",
     "sys.path.append('../../')\n",
     "from src.utilities.make_state_vector_file import cluster_buffer_elements\n",
     "from src.utilities.utils import download_landcover_files, download_hemcodiags_files\n",

--- a/src/notebooks/visualization_notebook.ipynb
+++ b/src/notebooks/visualization_notebook.ipynb
@@ -46,7 +46,8 @@
     "\n",
     "import warnings\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\", category=FutureWarning)"
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
+    "warnings.filterwarnings(\"ignore\", message=\"PROJ: proj_create_from_database\")"
    ]
   },
   {
@@ -974,7 +975,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {

--- a/src/notebooks/visualization_notebook.ipynb
+++ b/src/notebooks/visualization_notebook.ipynb
@@ -46,8 +46,7 @@
     "\n",
     "import warnings\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
-    "warnings.filterwarnings(\"ignore\", message=\"PROJ: proj_create_from_database\")"
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning)"
    ]
   },
   {


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada and James East
Institution: Harvard ACMG

### Describe the update
IMI preview was assuming the number of superobservations in each state vector element was the number of observation days. This will be an overestimate because some days sv elements will not be observed. The fix was to properly account for the number of superobservations by counting the number of *successful observation days*.

However, once the fix was applied the IMI preview underestimated the actual DOFS. Using a 1 month CONUS inversion as a test case. The original code estimated a DOFS of 19, the updated code found DOFS of 7, and the actual was 29. The systematic underestimate is likely due to only considering emissions having sensitivity to local observations.

To fix this underestimate, we consider observations within the state vector element and observations up to 2 grid cells away from the state vector element. In our test case this estimates a DOFS of 31. This is the approach used in Nesser et al., 2021, except they used observations up to 3 grid cells away.

