### PR TITLE
Feature/geoschem14.4.3 update

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -134,7 +134,7 @@ mkdir -p -v ${RunDirs}
 
 # Set/Collect information about the GEOS-Chem version, IMI version,
 # and TROPOMI processor version
-GEOSCHEM_VERSION=14.4.1
+GEOSCHEM_VERSION=14.4.3
 IMI_VERSION=$(git describe --tags)
 TROPOMI_PROCESSOR_VERSION=$(grep 'VALID_TROPOMI_PROCESSOR_VERSIONS =' src/utilities/download_TROPOMI.py |
     sed 's/VALID_TROPOMI_PROCESSOR_VERSIONS = //' |


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
Update companion geoschem version for the IMI to version 14.4.3. Importantly, this update to geoschem defaults to using TURBDAY instead of VDIFF for PBL mixing. @nicholasbalasus found VDIFF does not conserve mass. In future versions of geoschem, the default will be switched back to VDIFF once the mass conservation issue is fixed.