### PR TITLE
Stats Save from Notebook

### DIFF
--- a/src/notebooks/visualization_notebook.ipynb
+++ b/src/notebooks/visualization_notebook.ipynb
@@ -117,7 +117,7 @@
     ")\n",
     "posterior_viz_dir = \"./data_visualization_posterior\"\n",
     "\n",
-    "plot_save_path = (\"./plots\" if not config[\"KalmanMode\"] else f\"../plots/period_{period}_plots\")"
+    "plot_save_path = (\"./output\" if not config[\"KalmanMode\"] else f\"../output/period_{period}_plots\")"
    ]
   },
   {
@@ -985,6 +985,43 @@
     "    is_regional=config[\"isRegional\"],\n",
     "    save_path=plot_save_path\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Output statistics to a CSV file\n",
+    "statistics = {\n",
+    "    \"PriorEmissions\": total_prior_emissions,\n",
+    "    \"PosteriorEmissions\": total_posterior_emissions,\n",
+    "    \"DOFS\": DOFS,\n",
+    "    \"BiasPrior\": prior_bias,\n",
+    "    \"BiasPosterior\": posterior_bias,\n",
+    "    \"BiasPrior_std\": prior_std,\n",
+    "    \"BiasPosterior_std\": posterior_std,\n",
+    "    \"RMSEPrior\": prior_RMSE,\n",
+    "    \"RMSEPosterior\": posterior_RMSE,\n",
+    "    \"NumSuperObservations\": count_obs_in_mask(mask, df_copy),\n",
+    "    # Sectoral Totals\n",
+    "}\n",
+    "\n",
+    "sector_totals = {}\n",
+    "\n",
+    "for item in combined_sorted:\n",
+    "    category = item[0]\n",
+    "    prior = item[1]\n",
+    "    posterior = item[2]\n",
+    "    sector_totals[f\"{category}Prior\"] = prior\n",
+    "    sector_totals[f\"{category}Posterior\"] = posterior\n",
+    "\n",
+    "statistics.update(sector_totals)\n",
+    "\n",
+    "# Save the statistics to a file\n",
+    "stats_pd = pd.DataFrame(statistics, index=[0])\n",
+    "stats_pd.to_csv(f\"{plot_save_path}/viz_notebook_statistics.csv\", index=False)"
    ]
   },
   {


### PR DESCRIPTION
Added cell to visualization notebook to save out stats from the notebook to the output directory (previously called plots)

Added stats are:

"PriorEmissions": total_prior_emissions,
    "PosteriorEmissions": total_posterior_emissions,
    "DOFS": DOFS,
    "BiasPrior": prior_bias,
    "BiasPosterior": posterior_bias,
    "BiasPrior_std": prior_std,
    "BiasPosterior_std": posterior_std,
    "RMSEPrior": prior_RMSE,
    "RMSEPosterior": posterior_RMSE,
    "NumSuperObservations": count_obs_in_mask(mask, df_copy),
    # Sectoral Totals - Prior/Posterior
