### PR TITLE
Bugfix for calculating jacobian scale factor

### DIFF
--- a/src/inversion_scripts/get_jacobian_scalefactors.py
+++ b/src/inversion_scripts/get_jacobian_scalefactors.py
@@ -49,7 +49,7 @@ def get_jacobian_scalefactors(period_number, inv_directory, ref_directory):
     # Note 2: This also assumes that the temporal variabily of the swapped emissions is the same.
     # If the temporal variability is different, there will be error associated with scaling
     # the Jacobian.
-    sf_K = pert_sf / ref_pert_sf
+    sf_K = ref_pert_sf / pert_sf
 
     # Apply the target_emis_ratio to the scale factors
     sf_K = sf_K * target_emis_ratio


### PR DESCRIPTION
### Name and Institution (Required)

Name: Megan He
Institution: Harvard ACMG

### Describe the update

This fixes the calculation of scale factors to apply to the precomputed jacobian (previously in #275). The scale factor should be calculated as the reference perturbation scale factor divided by the "new" perturbation scale factor (i.e., `ref_pert_sf / pert_sf`. 

This ratio is effectively scaling the jacobian by the new total emissions divided by the reference total emissions: `ref_pert_sf / pert_sf = (target emissions / reference emissions) / (target emissions / new emissions) = new emissions / reference emissions`.