### PR TITLE
Add informative error for corrupt Jacobian files

### DIFF
--- a/src/inversion_scripts/operators/operator_utilities.py
+++ b/src/inversion_scripts/operators/operator_utilities.py
@@ -222,7 +222,11 @@ def concat_tracers(run_id, gc_date, config, sv_elems, n_elements, baserun=False)
 
     ds_concat = xr.concat([dsmf[v] for v in keepvars], "element").rename("ch4")
     ds_concat = ds_concat.to_dataset().assign_attrs(dsmf.attrs)
-    ds_concat = ds_concat.isel(time=gc_date.hour, drop=True)  # subset hour of interest
+    try:
+        ds_concat = ds_concat.isel(time=gc_date.hour, drop=True)  # subset hour of interest
+    except Exception as e:
+        print(f"Run id {run_id}. Failed at {gc_date} with error: {e}", flush=True)
+        raise e
     if not baserun:
         ds_concat = ds_concat.assign_coords({"element": sv_elems})
     return ds_concat


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
Print out the jacobian number and date that is corrupt when calculating the jacobian matrix from the perturbation simulations. Shoutout to @megan-he for this. This can be very helpful for debugging errors.