### PR TITLE
fix for misapplication of perturbation delta in jacobian sensitivity calculation

### DIFF
--- a/src/components/jacobian_component/make_perturbation_sf.py
+++ b/src/components/jacobian_component/make_perturbation_sf.py
@@ -124,6 +124,14 @@ def calculate_sfs(state_vector, emis_prior, target_emission=1e-8, prior_sf=None)
 
     # calculate the effective scale factors
     effective_pert_sf = jacobian_pert_sf / flat_prior_sf
+    
+    # subtract 1.0 from the effective scale factors to get the percent 
+    # change used in the inversion sensitivity calculations
+    # eg. 50% == 0.5
+    # This is is different from the jacobian simulations
+    # where we apply the "jacobian_pert_sf" in HEMCO.
+    # 50% perturbation is represented by SF of 1.5
+    effective_pert_sf = effective_pert_sf - 1.0
 
     # return dictionary of scale factor arrays
     perturbation_dict = {

--- a/src/inversion_scripts/invert.py
+++ b/src/inversion_scripts/invert.py
@@ -43,7 +43,7 @@ def do_inversion(
 
     Returns
         xhat         [float] : Posterior scaling factors
-        ratio        [float] : Change from prior     [xhat = 1 + ratio]
+        delta_optimized        [float] : Change from prior     [xhat = 1 + delta_optimized]
         KTinvSoK     [float] : K^T*inv(S_o)*K        [part of inversion equation]
         KTinvSoyKxA  [float] : K^T*inv(S_o)*(y-K*xA) [part of inversion equation]
         S_post       [float] : Posterior error covariance matrix
@@ -92,8 +92,8 @@ def do_inversion(
     #
     # In the code below this becomes
     #   xhat = xA + inv(gamma*KTinvSoK + inv(S_a)) * gamma*KTinvSoyKxA
-    #        = xA + ratio
-    #        = 1  + ratio      [since xA=1 when optimizing scale factors]
+    #        = xA + delta_optimized
+    #        = 1  + delta_optimized      [since xA=1 when optimizing scale factors]
     #
     # We build KTinvSoK and KTinvSoyKxA "piece by piece", loading one jacobian .pkl file at a
     # time. This is so that we don't need to assemble or invert the full Jacobian matrix, which
@@ -253,15 +253,15 @@ def do_inversion(
     inv_Sa = np.diag(1 / Sa_diag)  # Inverse of prior error covariance matrix
 
     # Solve for posterior scale factors xhat
-    ratio = np.linalg.inv(gamma * KTinvSoK + inv_Sa) @ (gamma * KTinvSoyKxA)
+    delta_optimized = np.linalg.inv(gamma * KTinvSoK + inv_Sa) @ (gamma * KTinvSoyKxA)
 
     # Update scale factors by 1 to match what GEOS-Chem expects
-    # xhat = 1 + ratio
+    # xhat = 1 + delta_optimized
     # Notes:
     #  - If optimizing BCs, the last 4 elements are in concentration space,
     #    so we do not need to add 1
     #  - If optimizing OH, the last element also needs to be updated by 1
-    xhat = ratio.copy()
+    xhat = delta_optimized.copy()
     xhat[:scale_factor_idx] += 1
     if oh_optimization:
         if is_Regional:
@@ -277,10 +277,10 @@ def do_inversion(
     # Averaging kernel matrix
     A = np.identity(n_elements) - S_post @ inv_Sa
 
-    # Calculate J_A, where ratio = xhat - xA
+    # Calculate J_A, where delta_optimized = xhat - xA
     # J_A = (xhat - xA)^T * inv_Sa * (xhat - xA)
-    ratioT = ratio.transpose()
-    J_A = ratioT @ inv_Sa @ ratio
+    delta_optimizedT = delta_optimized.transpose()
+    J_A = delta_optimizedT @ inv_Sa @ delta_optimized
     J_A_normalized = J_A / n_elements
 
     # Print some statistics
@@ -297,7 +297,7 @@ def do_inversion(
         xhat[:scale_factor_idx].max(),
     )
 
-    return xhat, ratio, KTinvSoK, KTinvSoyKxA, S_post, A
+    return xhat, delta_optimized, KTinvSoK, KTinvSoyKxA, S_post, A
 
 
 if __name__ == "__main__":
@@ -341,7 +341,7 @@ if __name__ == "__main__":
         is_Regional,
     )
     xhat = out[0]
-    ratio = out[1]
+    delta_optimized = out[1]
     KTinvSoK = out[2]
     KTinvSoyKxA = out[3]
     S_post = out[4]
@@ -353,13 +353,13 @@ if __name__ == "__main__":
     nvar2 = dataset.createDimension("nvar2", n_elements)
     nc_KTinvSoK = dataset.createVariable("KTinvSoK", np.float32, ("nvar1", "nvar2"))
     nc_KTinvSoyKxA = dataset.createVariable("KTinvSoyKxA", np.float32, ("nvar1"))
-    nc_ratio = dataset.createVariable("ratio", np.float32, ("nvar1"))
+    nc_delta_optimized = dataset.createVariable("ratio", np.float32, ("nvar1"))
     nc_xhat = dataset.createVariable("xhat", np.float32, ("nvar1"))
     nc_S_post = dataset.createVariable("S_post", np.float32, ("nvar1", "nvar2"))
     nc_A = dataset.createVariable("A", np.float32, ("nvar1", "nvar2"))
     nc_KTinvSoK[:, :] = KTinvSoK
     nc_KTinvSoyKxA[:] = KTinvSoyKxA
-    nc_ratio[:] = ratio
+    nc_delta_optimized[:] = delta_optimized
     nc_xhat[:] = xhat
     nc_S_post[:, :] = S_post
     nc_A[:, :] = A

--- a/src/inversion_scripts/operators/TROPOMI_operator.py
+++ b/src/inversion_scripts/operators/TROPOMI_operator.py
@@ -257,13 +257,13 @@ def apply_average_tropomi_operator(
             perturbations = np.full(n_elements, 1.0, dtype=float)
 
             if config["OptimizeOH"]:
-                oh_perturbation = config["PerturbValueOH"]
+                oh_perturbation = float(config["PerturbValueOH"]) - 1.0
             else:
-                oh_perturbation = 1.0
+                oh_perturbation = 1.0 # should these be 0.0?
             if config["OptimizeBCs"]:
                 bc_perturbation = config["PerturbValueBCs"]
             else:
-                bc_perturbation = 1.0
+                bc_perturbation = 1.0 # should these be 0.0?
 
             # fill perturbation array with OH and BC perturbations
             perturbations[0 : is_emis.sum()] = emis_perturbations


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
When we calculate our jacobian matrix we do the following calculation:
`sensitivity_xch4 = delta_xch4 / perturbation`
where the perturbation is the fractional change from the original emissions eg. 50% perturbation translates to a perturbation = 0.5. 

However, in HEMCO_Config.rc, when we apply the perturbation, a 50% perturbation is represented by a scale factor of 1.5. 

Since the introduction of #226, we did not account for this difference between the representations of the perturbation in HEMCO vs in the jacobian calculation. This introduces an error in the jacobian calculation. Luckily, since the emission perturbations are relatively high (targeting 1e-08 kg/m2/s) the impact on results should be relatively small. For example, if an emission element was perturbed by 52x, the jacobian calculations goes from `sensitivity_xch4 = delta_xch4 / 52` to `sensitivity_xch4 = delta_xch4 / 51`. This expectation is confirmed by my CONUS work for 2019 which goes from 41.075 --> 40.810 Tg/a. Absolute differences shown in the image below.

For OH, we are using a relatively small (10%) perturbation, so this bug matters a lot and would lead to very low sensitivity of OH to the observations in the jacobian. 

This bugfix addresses this issue for both the emission elements and the OH elements.

To avoid recalculating the jacobian if perturbation simulations were already deleted, users can update `invert.py` to do the following rescaling of K:
```
        pert_sfs = np.load("../archive_perturbation_sfs/pert_sf_1.npz")["effective_pert_sf"]
        scaling_matrix = pert_sfs / (pert_sfs - 1)
        
        if bc_optimization:
            # add four elements for BCs
            scaling_matrix = np.append(scaling_matrix, np.ones(4))
        if oh_optimization:
            # add two elements for OH
            scaling_matrix = np.append(scaling_matrix, (1.1 / .1) * np.ones(2))
        
        K *= scaling_matrix
```
![image](https://github.com/user-attachments/assets/467d7a4e-8ded-4cc4-acb2-5514b96b8f07)
