### PR TITLE
Add fixes to *invert.py scripts to properly determine number of OH elements

### DIFF
--- a/src/inversion_scripts/invert.py
+++ b/src/inversion_scripts/invert.py
@@ -192,7 +192,7 @@ def do_inversion(
                 scale_factors = np.append(scale_factors, np.ones(4))
             reps = K.shape[0]
             scaling_matrix = np.tile(scale_factors, (reps, 1))
-            if optimize_oh
+            if optimize_oh:
                 if is_Regional:
                     K[:, :-1] *= scaling_matrix
                 else:

--- a/src/inversion_scripts/invert.py
+++ b/src/inversion_scripts/invert.py
@@ -59,8 +59,8 @@ def do_inversion(
 
     """
     # boolean for whether we are optimizing boundary conditions
-    bc_optimization = prior_err_bc > 0.0
-    oh_optimization = prior_err_oh > 0.0
+    optimize_bc = prior_err_bc > 0.0
+    optimize_oh = prior_err_oh > 0.0
 
     # Need to ignore data in the GEOS-Chem 3 3 3 3 buffer zone
     # Shave off one or two degrees of latitude/longitude from each side of the domain
@@ -186,14 +186,17 @@ def do_inversion(
         # Apply scaling matrix if using precomputed Jacobian
         if jacobian_sf is not None:
             scale_factors = np.load(jacobian_sf)
-            if bc_optimization:
+            if optimize_bc:
                 # add (unit) scale factors for BCs
                 # as the last 4 elements of the scaling matrix
                 scale_factors = np.append(scale_factors, np.ones(4))
             reps = K.shape[0]
             scaling_matrix = np.tile(scale_factors, (reps, 1))
-            if oh_optimization:
-                K[:, :-2] *= scaling_matrix
+            if optimize_oh
+                if is_Regional:
+                    K[:, :-1] *= scaling_matrix
+                else:
+                    K[:, :-2] *= scaling_matrix
             else:
                 K *= scaling_matrix
 
@@ -234,7 +237,7 @@ def do_inversion(
     scale_factor_idx = n_elements
 
     # If optimizing OH, adjust for it in the inversion
-    if oh_optimization:
+    if optimize_oh:
         # Add prior error for OH as the last element(s) of the diagonal
         # Following Masakkers et al. (2019, ACP) weight the OH term by the
         # ratio of the number of elements (n_OH_elements/n_emission_elements)
@@ -248,11 +251,11 @@ def do_inversion(
             scale_factor_idx -= 2
 
     # If optimizing boundary conditions, adjust for it in the inversion
-    if bc_optimization:
+    if optimize_bc:
         scale_factor_idx -= 4
 
         # add prior error for BCs as the last 4 elements of the diagonal
-        if oh_optimization:
+        if optimize_oh:
             if is_Regional:
                 Sa_diag[-5:-1] = prior_err_bc**2
             else:
@@ -273,7 +276,7 @@ def do_inversion(
     #  - If optimizing OH, the last element also needs to be updated by 1
     xhat = delta_optimized.copy()
     xhat[:scale_factor_idx] += 1
-    if oh_optimization:
+    if optimize_oh:
         if is_Regional:
             xhat[-1] += 1
             print(f"xhat[OH] = {xhat[-1]}")

--- a/src/inversion_scripts/lognormal_invert.py
+++ b/src/inversion_scripts/lognormal_invert.py
@@ -64,7 +64,14 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
     # normal elements.
     optimize_bcs = config["OptimizeBCs"]
     optimize_oh = config["OptimizeOH"]
-    OH_element_num = 1 if optimize_oh else 0
+    is_regional = config["isRegional"]
+    if optimize_oh:
+        if is_regional:
+            OH_element_num = 1
+        else:
+            OH_element_num = 2
+    else:
+        OH_element_num = 0
     BC_element_num = 4 if optimize_bcs else 0
     num_sv_elems = (
         int(state_vector_labels.max().item()) + OH_element_num + BC_element_num


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

In `lognormal_inverty.py` it was automatically assumed that the number of OH elements is 1 when setting `OptimizeOH: true`. This is only the case for regional simulations. For global simulations, OH_element_num should be 2.

In `invert.py`, a fix was needed to select the right element in K when using OH optimization in regional vs global simulations. In addition, the logicals for BC and OH optimization have been renamed in this script for consistency with `lognormal_invert.py`.

Also tagging @megan-he and @laestrada who brought this issue to my attention.