### PR TITLE
Fix potential slurm misconfiguration

### DIFF
--- a/envs/aws/slurm/configure_slurm.py
+++ b/envs/aws/slurm/configure_slurm.py
@@ -2,9 +2,9 @@
 Intended to configure Slurm by editing slurm.conf with instance-specific info. 
 Should output to new_slurm.conf something similar to the following:
 
-NodeName=ip-172-31-6-14 CPUs=36 RealMemory=94432 CoresPerSocket=36 ThreadsPerCore=1 State=UNKNOWN
+ControlMachine=ip-172-31-6-14
+NodeName=ip-172-31-6-14 CPUs=36 SocketsPerBoard=1 CoresPerSocket=36 ThreadsPerCore=1 RealMemory=94432 State=UNKNOWN
 PartitionName=debug Nodes=ip-172-31-6-14 Default=YES MaxTime=INFINITE State=UP
-'ControlMachine=ip-172-31-6-14'
 """
 
 import subprocess
@@ -19,11 +19,13 @@ second_line = (
     " ".join(
         [
             "\n",
-            slurm_info[0],
-            slurm_info[1],
-            slurm_info[6],
-            "SocketsPerBoard" + slurm_info[1][4:],
-            "ThreadsPerCore=1 State=UNKNOWN",
+            slurm_info[0], # NodeName
+            slurm_info[1], # CPUs
+            slurm_info[3], # SocketsPerBoard
+            slurm_info[4], # CoresPerSocket
+            slurm_info[5], # ThreadsPerCore
+            slurm_info[6], # RealMemory
+            "State=UNKNOWN",
         ]
     )
     + "\n"


### PR DESCRIPTION
### Name and Institution

Name: Stefanos Chatzimichelakis
Institution: Freelancer, on behalf of 2Celcius

### Describe the update

Modified `configure_slurm.py` to use the `slurmd -C` output as-is, without hardcoded values or other manipulations, to fix a potential issue with wrong ThreadsPerCore and SocketsPerBoard values.

####  Issue addressed

When the script parses the output of `slurmd -C` to add instance-specific directives to `/etc/slurmd/slurm.conf`, it takes the `CPUs` value and uses it for the `SocketsPerBoard` parameter, and also hardcodes `ThreadsPerCore` to 1. 

For example, for the recommended c5.x9large instance type, if `slurmd -C` outputs
`NodeName=ip-172-31-66-122 CPUs=36 Boards=1 SocketsPerBoard=1 CoresPerSocket=18 ThreadsPerCore=2 RealMemory=70305`
the resulting slurm.conf directive is
`NodeName=ip-172-31-66-122 CPUs=36 RealMemory=70305 SocketsPerBoard=36 ThreadsPerCore=1 State=UNKNOWN`

This behavior seems to result in underutilisation of resources (cpu utilization maxes out at 50% during the jacobian runs).

Correcting the slurm.conf entry to align with the `slurmd -C` output:
`NodeName=ip-172-31-66-122 CPUs=36 RealMemory=70305 SocketsPerBoard=1 CoresPerSocket=18 ThreadsPerCore=2 State=UNKNOWN`
reduces the duration of the jacobian runs by more than half. Similar results were observed in larger instances as well (e.g. c6i.24xlarge).