### PR TITLE
minor fix to prior sbatch command

### DIFF
--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -472,6 +472,7 @@ run_jacobian() {
         sbatch --mem $RequestedMemory \
             -c $RequestedCPUs \
             -t $RequestedTime \
+            -o imi_output.tmp \
             -p $SchedulerPartition \
             -W run_prior_simulation.sh
         wait


### PR DESCRIPTION
### Name and Institution (Required)

Name: Stefanos Chatzimichelakis
Institution: Freelancer, on behalf of 2Celcius

### Describe the update

Added missing output parameter in the prior simulation sbatch command when using pre-computed jacobian

#### Issue addressed

The prior simulation sbatch command ran by the `PreComputedJacobian` branch of the `run_jacobian()` function of `src/components/jacobian_component/jacobian.sh` is expected to output to `imi_output.tmp` , but the `-o` parameter is missing, resulting in an unrecoverable error during the run.
