### PR TITLE
feature/sectoral_preview_plot

### DIFF
--- a/src/inversion_scripts/imi_preview.py
+++ b/src/inversion_scripts/imi_preview.py
@@ -280,6 +280,8 @@ def imi_preview(
         dpi=150,
     )
 
+   
+
     # Plot albedo
     fig = plt.figure(figsize=(10, 8))
     ax = fig.subplots(1, 1, subplot_kw={"projection": ccrs.PlateCarree()})
@@ -369,6 +371,8 @@ def imi_preview(
         dpi=150,
     )
 
+    
+
     # calculate expected DOFS
     expectedDOFS = np.round(sum(a), 5)
     if expectedDOFS < config["DOFSThreshold"]:
@@ -449,7 +453,7 @@ def estimate_averaging_kernel(
 
         # use the nudged (prior) emissions for generating averaging kernel estimate
         sf = xr.load_dataset(f"{rundir_path}archive_sf/prior_sf_period{kf_index}.nc")
-        prior_ds = get_mean_emissions(startday, endday, prior_cache)
+        get_mean_emissions(startday, endday, prior_cache)
         prior_ds = get_posterior_emissions(prior_ds, sf)
     else:
         prior_ds = get_mean_emissions(startday, endday, prior_cache)
@@ -463,6 +467,60 @@ def estimate_averaging_kernel(
         f"Total prior emissions in region of interest = {total_prior_emissions} Tg/y \n"
     )
     print(outstring1)
+
+    # Plot sectoral emissions
+    sectors = [
+        var
+        for var in list(prior_ds.keys())
+        if "EmisCH4" in var and not ("Total" in var or "Excl" in var)
+    ]
+
+    # Calculate total emissions for each sector
+    prior_sector_vals = []
+    positive_sectors = []
+    for sector in sectors:
+        prior_val = sum_total_emissions(prior_ds[sector], areas, mask)
+        if prior_val > 0:
+            prior_sector_vals.append(prior_val)
+            positive_sectors.append(sector.replace("EmisCH4_", ""))
+
+    # Combine the lists into tuples and sort them based on prior_sector_vals
+    combined = list(zip(positive_sectors, prior_sector_vals))
+    combined_sorted = sorted(combined, key=lambda x: x[1])
+    positive_sectors, prior_sector_vals = zip(*combined_sorted)
+
+    # Plot bars for prior emissions
+    fig = plt.figure(figsize=(10, 5))
+    ax = fig.subplots(1, 1)
+    bar_height = 0.35
+    ind = np.arange(len(positive_sectors))
+    bars1 = ax.barh(
+        ind,
+        prior_sector_vals,
+        bar_height,
+        color="goldenrod",
+        label="Prior Emissions",
+    )
+
+    # Add labels and title
+    ax.set_xlabel("Emissions ($Tg\ a^{-1}$)")
+    ax.set_ylabel("Sector")
+    ax.set_title("Sectoral emissions")
+    ax.set_yticks(ind)
+    ax.set_yticklabels(positive_sectors)
+
+    plt.savefig(f"{preview_dir}/prior_sectoral_emissions.png", bbox_inches="tight")
+
+    sector_totals = {}
+
+    for item in combined_sorted:
+        category = item[0]
+        sector_prior = item[1]
+        sector_totals[f"{category}Prior"] = sector_prior
+
+    # Save the statistics to a file
+    stats_pd = pd.DataFrame(sector_totals, index=[0])
+    stats_pd.to_csv(f"{preview_dir}/prior_sectoral_statistics.csv", index=False)
 
     # ----------------------------------
     # Observations in region of interest


### PR DESCRIPTION
- Adds functionality in the preview to download plot of prior sectoral emissions (bar chart)
- Downloads sectoral emissions csv for use in Integral Earth plot building

Both new output files are exported into the existing preview output dir as preview_sectoral_emissions.png and prior_sectoral_statistics.csv.

Tested on Permian case.