### PR TITLE
Turn soil absorption on in background simulation

### DIFF
--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -272,6 +272,13 @@ create_simulation_dir() {
         # Use MeMo soil absorption for the prior simulation
         sed -i -e "/(((MeMo_SOIL_ABSORPTION/i ))).not.UseTotalPriorEmis" \
             -e "/)))MeMo_SOIL_ABSORPTION/a (((.not.UseTotalPriorEmis" HEMCO_Config.rc
+
+        # create a break in EMISSIONS logic block for MeMo in background simulation
+        if [[ "$x" = "background" ]]; then
+            sed -i -e "/(((MeMo_SOIL_ABSORPTION/i )))EMISSIONS" HEMCO_Config.rc
+            sed -i -e "/)))MeMo_SOIL_ABSORPTION/a (((EMISSIONS" HEMCO_Config.rc
+        fi
+
         if "$KalmanMode"; then
             # Use nudged scale factors for the prior simulation and OH simulation for kalman mode
             sed -i -e "s|--> Emis_PosteriorSF       :       false|--> Emis_PosteriorSF       :       true|g" \


### PR DESCRIPTION
Name: James East
Institution: Harvard ACMG

### Describe the update

In the lognormal inversion, the background simulation has TROPOMI initial and boundary conditions, OH loss, and no emissions. It should also have soil absorption, but it doesn't. This PR turns on MeMo soil absorption in the background simulation in lognormal inversions. Lognormal inversions done without this fix have an overcorrection, the magnitude is probably small.

Without soil absorption turned on in the background, Kx+background does not match the prior/posterior simulation:
![S5_kx_vs_gc_no-soil (2)](https://github.com/user-attachments/assets/71eaabda-2ae6-4a6b-9471-a790a07ba78c)

With soil absorption in the background simulation, Kx+background matches the prior/posterior simulation:
![S5_kx_vs_gc_soil (3)](https://github.com/user-attachments/assets/75c79835-721b-4aa1-86dd-0a96477b1ede)
