### PR TITLE
Update GEOS-Chem version to 14.6.1

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -137,7 +137,7 @@ mkdir -p -v ${RunDirs}
 
 # Set/Collect information about the GEOS-Chem version, IMI version,
 # and TROPOMI processor version
-GEOSCHEM_VERSION=14.4.1
+GEOSCHEM_VERSION=14.6.1
 IMI_VERSION=$(git describe --tags)
 TROPOMI_PROCESSOR_VERSION=$(grep 'VALID_TROPOMI_PROCESSOR_VERSIONS =' src/utilities/download_TROPOMI.py |
     sed 's/VALID_TROPOMI_PROCESSOR_VERSIONS = //' |

--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -29,7 +29,8 @@ setup_template() {
     if [[ "$Met" == "MERRA2" || "$Met" == "MERRA-2" || "$Met" == "merra2" ]]; then
         metNum="1"
     elif [[ "$Met" == "GEOSFP" || "$Met" == "GEOS-FP" || "$Met" == "geosfp" ]]; then
-        metNum="2"
+	# Add y to metNum to skip prompt about GEOS-FP discontinuity
+        metNum="2\ny"
     else
         printf "\nERROR: Meteorology field ${Met} is not supported by the IMI. "
         printf "\n Options are GEOSFP or MERRA2.\n"

--- a/src/write_BCs/run_boundary_conditions.sh
+++ b/src/write_BCs/run_boundary_conditions.sh
@@ -31,10 +31,10 @@ mkdir -p "${workDir}/tropomi-boundary-conditions"
 mkdir -p "${workDir}/blended-boundary-conditions"
 cd "${workDir}"
 
-# Get GCClassic v14.4.1 and create the run directory
+# Get GCClassic v14.6.1 and create the run directory
 git clone https://github.com/geoschem/GCClassic.git
 cd GCClassic
-git checkout 14.4.1
+git checkout 14.6.1
 git submodule update --init --recursive
 cd run
 runDir="gc_run"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

This PR updates the version of GEOS-Chem from 14.4.1 to 14.6.1. Major updates to the methane simulation between these versions include:

- Mass conservation fix in mixing scheme (Nick Balasus)
- Seasonality of hydropower reservoir emissions (Melissa Sulprizio)
- Fix for double counting of agricultural burning emissions (Nick Balasus)
- Update rice emissions to GRPI (Zichong Chen)
- Update to GFEI v3 (Tia Scarpelli)
- Adding the option for 12km (0.125x0.15625 resolution) regional simulations (Xiaolin Wang, Melissa Sulprizio)
- Fixes to eliminate differences between the carbon and CH4 simulations

This PR supersedes https://github.com/geoschem/integrated_methane_inversion/pull/293 
