### PR TITLE
Add bug fix for generating GEOS-Chem run directories for regional runs

### DIFF
--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -96,14 +96,6 @@ setup_template() {
         sed -i -e "s|gridded_posterior.nc|${RunDirs}/ScaleFactors.nc|g" HEMCO_Config.rc
     fi
 
-    # Modify HEMCO_Config.rc based on settings in config.yml
-    # Use cropped met fields (add the region to both METDIR and the met files)
-    if [ "$RegionID" != "" ]; then
-        sed -i -e "s:GEOS_${Res}:GEOS_${Res}_${RegionID}:g" HEMCO_Config.rc
-        sed -i -e "s:GEOS_${Res}:GEOS_${Res}_${RegionID}:g" HEMCO_Config.rc.gmao_metfields
-        sed -i -e "s:\$RES:\$RES.${RegionID}:g" HEMCO_Config.rc.gmao_metfields
-    fi
-
     # By default, only output emissions at the end of the simulation
     sed -i -e "s|DiagnFreq:                   Monthly|DiagnFreq:                   End|g" HEMCO_Config.rc
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

In GEOS-Chem 14.6.0, updates were made to the run directory creation script to automatically add the region ID to the met field directory and name in the run directory's HEMCO configuration file. The code to do this in the IMI's template.sh script is no longer needed.