### PR TITLE
Speed up merge_partial_k.py by pre allocating list

### DIFF
--- a/src/inversion_scripts/merge_partial_k.py
+++ b/src/inversion_scripts/merge_partial_k.py
@@ -68,7 +68,6 @@ def merge_partial_k(satdat_dir, lat_bounds, lon_bounds, obs_errs, precomp_K):
     K_list = [None for i in range(len(files))]
 
     for i, f in enumerate(files):
-        print(f'\r{f}',end='')
         # Get paths
         pth = os.path.join(satdat_dir, f)
         # Get same file from bc folder

--- a/src/inversion_scripts/merge_partial_k.py
+++ b/src/inversion_scripts/merge_partial_k.py
@@ -108,11 +108,11 @@ def merge_partial_k(satdat_dir, lat_bounds, lon_bounds, obs_errs, precomp_K):
             obs_error = calc_so(obs_err, obs_GC)
             so_dict[key][i] = obs_error
 
-    K = np.concatenate(list(filter(None, K_list)), axis=0)
-    geos_prior = np.concatenate(list(filter(None, geos_prior_list)), axis=0)
-    tropomi = np.concatenate(list(filter(None, tropomi_list)), axis=0)
+    K = np.concatenate(K_list, axis=0)
+    geos_prior = np.concatenate(geos_prior_list, axis=0)
+    tropomi = np.concatenate(tropomi_list, axis=0)
     for k,v in so_dict.items():
-        so_dict[k] = np.concatenate(list(filter(None, v)), axis=0)
+        so_dict[k] = np.concatenate(v, axis=0)
 
     gc_ch4_prior = np.asmatrix(geos_prior)
     obs_tropomi = np.asmatrix(tropomi)


### PR DESCRIPTION
### Name and Institution (Required)

Name: James East
Institution: Harvard

### Describe the update

Speed up `merge_partial_k.py` by pre-allocating a list that will contain the jacobian before looping through the files. Previously, we concatenated an array as we went, but this was slow. For a particularly large case for me, `merge_partial_k.py` was taking >60 mins. With this change, it took <3 mins.

Not yet tested with dev.