### PR TITLE
Update GEOS-Chem version to 14.6.2

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -138,7 +138,7 @@ mkdir -p -v ${RunDirs}
 
 # Set/Collect information about the GEOS-Chem version, IMI version,
 # and TROPOMI processor version
-GEOSCHEM_VERSION=14.6.1
+GEOSCHEM_VERSION=14.6.2
 IMI_VERSION=$(git describe --tags)
 TROPOMI_PROCESSOR_VERSION=$(grep 'VALID_TROPOMI_PROCESSOR_VERSIONS =' src/utilities/download_TROPOMI.py |
     sed 's/VALID_TROPOMI_PROCESSOR_VERSIONS = //' |


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

GEOS-Chem versions 14.6.0 and 14.6.1 contained a bug that caused high CH4 concentrations due to improper units when applying the boundary conditions. See this Github issue for details: https://github.com/geoschem/geos-chem/issues/2890.

The [GEOS-Chem 14.6.2](https://github.com/geoschem/geos-chem/releases/tag/14.6.2) release includes a fix for this.