### PR TITLE
Update to v2025-06 BCs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -207,12 +207,12 @@ RestartDownload: true
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/home/ubuntu/ExtData/BoundaryConditions/v2024-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/home/ubuntu/ExtData/BoundaryConditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
 BCpath: "/home/ubuntu/ExtData/BoundaryConditions"
-BCversion: "v2024-06"
+BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3
 HemcoPriorEmisDryRun: true

--- a/docs/source/getting-started/imi-config-file.rst
+++ b/docs/source/getting-started/imi-config-file.rst
@@ -337,7 +337,7 @@ the IMI on a local cluster<../advanced/local-cluster>`).
    * - ``BCpath``
      - Path to GEOS-Chem boundary condition files (for regional simulations).
    * - ``BCversion``
-     - Version of TROPOMI smoothed boundary conditions to use (e.g. ``v2024-06``). Note: this will be appended onto BCpath as a subdirectory.
+     - Version of TROPOMI smoothed boundary conditions to use (e.g. ``v2025-06``). Note: this will be appended onto BCpath as a subdirectory.
    * - ``PreviewDryRun``
      - Boolean to download missing GEOS-Chem data for the preview run. Default value is ``true``.
    * - ``SpinupDryRun``

--- a/envs/Harvard-Cannon/config.harvard-cannon.12km.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.12km.yml
@@ -215,12 +215,12 @@ RestartDownload: false
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2024-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
 BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions"
-BCversion: "v2024-06"
+BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3
 ##   NOTE: Must have AWS CLI enabled

--- a/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
@@ -215,12 +215,12 @@ RestartDownload: false
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2024-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
 BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions"
-BCversion: "v2024-06"
+BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3
 ##   NOTE: Must have AWS CLI enabled

--- a/envs/Harvard-Cannon/config.harvard-cannon.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.yml
@@ -215,12 +215,12 @@ RestartDownload: false
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2024-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
 BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions"
-BCversion: "v2024-06"
+BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3
 ##   NOTE: Must have AWS CLI enabled

--- a/envs/MSU-HPC_Orion/config.msu-hpc_orion.global_inv.yml
+++ b/envs/MSU-HPC_Orion/config.msu-hpc_orion.global_inv.yml
@@ -211,12 +211,12 @@ RestartDownload: false
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/work/noaa/co2/METEO/IMI/CH4/tropomi-boundary-conditions/v2024-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/work/noaa/co2/METEO/IMI/CH4/tropomi-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
 BCpath: "/work/noaa/co2/METEO/IMI/CH4/tropomi-boundary-conditions"
-BCversion: "v2024-06"
+BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3
 ##   NOTE: Must have AWS CLI enabled

--- a/resources/containers/al2/container_config.yml
+++ b/resources/containers/al2/container_config.yml
@@ -202,12 +202,12 @@ RestartDownload: true
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/home/al2/ExtData/BoundaryConditions/v2024-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/home/al2/ExtData/BoundaryConditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
 BCpath: "/home/al2/ExtData/BoundaryConditions"
-BCversion: "v2024-06"
+BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3
 HemcoPriorEmisDryRun: true

--- a/src/utilities/download_bc.py
+++ b/src/utilities/download_bc.py
@@ -11,7 +11,7 @@ Description: Download boundary condition data from aws S3 bucket for
              desired dates. Function can be called from another script 
              or run as a directly as a script.
 Example Usage:
-    $ python download_bc.py 20200501 20200508 path/to/imi/boundary-conditions v2024-06
+    $ python download_bc.py 20200501 20200508 path/to/imi/boundary-conditions v2025-06
 """
 
 

--- a/src/write_BCs/README.md
+++ b/src/write_BCs/README.md
@@ -21,7 +21,7 @@
    - `debug`           - whether or not to delete the `debug.log`.
       - this includes information about your environment file and the build of GEOS-Chem.
       - all important information and errors are written to `boundary_conditions.log`.
-2. Run `sbatch -p huce_cascade run_boundary_conditions.sh`.
+2. Run `sbatch -p huce_ice run_boundary_conditions.sh`.
    - GEOS-Chem will be run first (2.0 x 2.5, GEOS-FP, CH4, 47 L, daily restart files).
    - Bias-corrected boundary conditions will be written via `write_boundary_conditions.py` (description in file).
    - In `workDir`, the folders `tropomi-boundary-conditions` and `blended-boundary-conditions` will be populated.

--- a/src/write_BCs/config_boundary_conditions.yml
+++ b/src/write_BCs/config_boundary_conditions.yml
@@ -3,7 +3,7 @@ startDate: "20180401"
 endDate: "20180531"
 
 ## A directory with a lot of space where you can write the BCs (and intermediate files)
-workDir: "/n/holylfs06/LABS/jacob_lab2/Lab/nbalasus/test"
+workDir: "/n/holylfs06/LABS/jacob_lab2/Lab/nbalasus/test-new"
 
 ## Paths to TROPOMI data and blended TROPOMI+GOSAT data
 tropomiDir: "/n/holylfs05/LABS/jacob_lab/Everyone/imi/ch4/tropomi"

--- a/src/write_BCs/config_boundary_conditions.yml
+++ b/src/write_BCs/config_boundary_conditions.yml
@@ -1,9 +1,9 @@
 ## Date range (inclusive) that you want to generate BCs for
 startDate: "20180401"
-endDate: "20180531"
+endDate: "20241231"
 
 ## A directory with a lot of space where you can write the BCs (and intermediate files)
-workDir: "/n/holylfs06/LABS/jacob_lab2/Lab/nbalasus/test-new"
+workDir: "/n/holylfs06/LABS/jacob_lab2/Lab/nbalasus/v2025-06-IMI-BCs/apr2018-dec2024"
 
 ## Paths to TROPOMI data and blended TROPOMI+GOSAT data
 tropomiDir: "/n/holylfs05/LABS/jacob_lab/Everyone/imi/ch4/tropomi"

--- a/src/write_BCs/config_boundary_conditions.yml
+++ b/src/write_BCs/config_boundary_conditions.yml
@@ -1,9 +1,9 @@
 ## Date range (inclusive) that you want to generate BCs for
 startDate: "20180401"
-endDate: "20240229"
+endDate: "20180531"
 
 ## A directory with a lot of space where you can write the BCs (and intermediate files)
-workDir: "/n/holylfs05/LABS/jacob_lab/Users/nbalasus/v2024-06-IMI-BCs"
+workDir: "/n/holylfs06/LABS/jacob_lab2/Lab/nbalasus/test"
 
 ## Paths to TROPOMI data and blended TROPOMI+GOSAT data
 tropomiDir: "/n/holylfs05/LABS/jacob_lab/Everyone/imi/ch4/tropomi"
@@ -14,7 +14,7 @@ condaEnv: imi_env
 condaFile: ~/.bashrc
 geosChemEnv: "../../envs/Harvard-Cannon/gcclassic.rocky+gnu12.minimal.env"
 geosChemDataPath: "/n/holylfs06/LABS/jacob_lab/Everyone/GEOS-CHEM/gcgrid/gcdata/ExtData"
-partition: huce_cascade,seas_compute,huce_ice
+partition: huce_ice
 
 ## A restart file for GEOS-Chem for your simulation start date
 restartFilePath: "/path/to/restart/file"

--- a/src/write_BCs/run_boundary_conditions.sh
+++ b/src/write_BCs/run_boundary_conditions.sh
@@ -31,14 +31,14 @@ mkdir -p "${workDir}/tropomi-boundary-conditions"
 mkdir -p "${workDir}/blended-boundary-conditions"
 cd "${workDir}"
 
-# Get GCClassic v14.4.1 and create the run directory
+# Get GCClassic v14.6.2 and create the run directory
 git clone https://github.com/geoschem/GCClassic.git
 cd GCClassic
-git checkout 14.4.1
+git checkout 14.6.2
 git submodule update --init --recursive
 cd run
 runDir="gc_run"
-c="9\n2\n2\n2\n${workDir}\n${runDir}\nn\n" # CH4, GEOS-FP, 2.0 x 2.5, 47L
+c="9\n2\ny\n2\n2\n${workDir}\n${runDir}\nn\n" # CH4, GEOS-FP, 2.0 x 2.5, 47L
 printf ${c} | ./createRunDir.sh
 cd "${workDir}/${runDir}/build"
 cmake ../CodeDir -DRUNDIR=..
@@ -49,6 +49,7 @@ cd "${workDir}/${runDir}"
 # Modify HISTORY.rc (hourly instantaneous CH4/pressure/air and 3-hourly BCs)
 sed -i -e "s|'CH4',|#'CH4',|g" \
     -e "s|'Metrics',|#'Metrics',|g" \
+    -e "s|'StateMet',|#'StateMet',|g" \
     -e "s|#'LevelEdgeDiags',|'LevelEdgeDiags',|g" \
     -e "s|Restart.frequency:          'End',|Restart.frequency:          '00000001 000000',|g" \
     -e "s|Restart.duration:           'End',|Restart.duration:           '00000001 000000',|g" \
@@ -56,10 +57,9 @@ sed -i -e "s|'CH4',|#'CH4',|g" \
     -e "s|time-averaged|instantaneous|g" \
     -e "s|Met_CMFMC|Met_PEDGE|g" \
     -e "s|#'BoundaryConditions',|'BoundaryConditions',|g" \
-    -e "s|'Met_AD                        ',|'Met_AIRVOL                    ',|g" HISTORY.rc
+    -e "s|'SpeciesBC_?ADV?             ',|'SpeciesBC_?ADV?_             ',\\n                                 'Met_AD                       ',|g" HISTORY.rc
 
-# Remove unnecessary StateMet and then LevelEdge variables
-sed -i '265,340d' HISTORY.rc
+# Remove unnecessary LevelEdge variables
 sed -i '195,200d' HISTORY.rc
 
 # Modify HEMCO_Config.rc so that GEOS-Chem can run into 2024

--- a/src/write_BCs/write_boundary_conditions.py
+++ b/src/write_BCs/write_boundary_conditions.py
@@ -270,9 +270,8 @@ def write_bias_corrected_files(bias):
             new_xch4 = original_xch4 - bias_for_this_boundary_condition_file
             ratio = new_xch4 / original_xch4
 
-            for t in range(mixing_ratio.shape[0]):
-                for lev in range(mixing_ratio.shape[1]):
-                    mixing_ratio[t, lev, :, :] *= ratio
+            for lev in range(mixing_ratio.shape[1]):
+                mixing_ratio[:, lev, :, :] *= ratio
 
             ds["SpeciesBC_CH4"].values = mixing_ratio
 

--- a/src/write_BCs/write_boundary_conditions.py
+++ b/src/write_BCs/write_boundary_conditions.py
@@ -270,11 +270,11 @@ def write_bias_corrected_files(bias):
             new_xch4 = original_xch4 - bias_for_this_boundary_condition_file
             ratio = new_xch4 / original_xch4
 
-            for t in range(original_data.shape[0]):
-                for lev in range(original_data.shape[1]):
-                    original_data[t, lev, :, :] *= ratio
+            for t in range(mixing_ratio.shape[0]):
+                for lev in range(mixing_ratio.shape[1]):
+                    mixing_ratio[t, lev, :, :] *= ratio
 
-            ds["SpeciesBC_CH4"].values = original_data
+            ds["SpeciesBC_CH4"].values = mixing_ratio
 
             if blendedTROPOMI:
                 print(

--- a/src/write_BCs/write_boundary_conditions.py
+++ b/src/write_BCs/write_boundary_conditions.py
@@ -276,29 +276,10 @@ def write_bias_corrected_files(bias):
 
             ds["SpeciesBC_CH4"].values = mixing_ratio
 
-            if blendedTROPOMI:
-                print(
-                    f"Writing to {os.path.join(config['workDir'], 'blended-boundary-conditions', os.path.basename(filename))}"
-                )
-                ds.to_netcdf(
-                    os.path.join(
-                        config["workDir"],
-                        "blended-boundary-conditions",
-                        os.path.basename(filename),
-                    )
-                )
-            else:
-                print(
-                    f"Writing to {os.path.join(config['workDir'], 'tropomi-boundary-conditions', os.path.basename(filename))}"
-                )
-                ds.to_netcdf(
-                    os.path.join(
-                        config["workDir"],
-                        "tropomi-boundary-conditions",
-                        os.path.basename(filename),
-                    )
-                )
-
+            subdir = "blended-boundary-conditions" if blendedTROPOMI else "tropomi-boundary-conditions"
+            output_path = os.path.join(config["workDir"], subdir, os.path.basename(filename))
+            print(f"Writing to {output_path}")
+            ds.to_netcdf(output_path)
 
 if __name__ == "__main__":
 

--- a/src/write_BCs/write_boundary_conditions.py
+++ b/src/write_BCs/write_boundary_conditions.py
@@ -27,18 +27,12 @@ def get_TROPOMI_times(filename):
     Example output (tuple): (np.datetime64('2022-07-25T15:27:51'), np.datetime64('2022-07-25T17:09:21'))
     """
 
-    file_times = re.search(r"(\d{8}T\d{6})_(\d{8}T\d{6})", filename)
-    assert (
-        file_times is not None
-    ), "check TROPOMI filename - wasn't able to find start and end times in the filename"
-    start_TROPOMI_time = np.datetime64(
-        datetime.datetime.strptime(file_times.group(1), "%Y%m%dT%H%M%S")
-    )
-    end_TROPOMI_time = np.datetime64(
-        datetime.datetime.strptime(file_times.group(2), "%Y%m%dT%H%M%S")
-    )
+    ftimes = re.search(r"(\d{8}T\d{6})_(\d{8}T\d{6})", filename)
+    assert ftimes is not None
+    begint = np.datetime64(datetime.datetime.strptime(ftimes.group(1), "%Y%m%dT%H%M%S"))
+    endt = np.datetime64(datetime.datetime.strptime(ftimes.group(2), "%Y%m%dT%H%M%S"))
 
-    return start_TROPOMI_time, end_TROPOMI_time
+    return begint, endt
 
 
 def apply_tropomi_operator_to_one_tropomi_file(filename):
@@ -51,36 +45,28 @@ def apply_tropomi_operator_to_one_tropomi_file(filename):
         filename=filename,
         BlendedTROPOMI=blendedTROPOMI,
         n_elements=False,  # Not relevant
-        gc_startdate=start_time_of_interest,
-        gc_enddate=end_time_of_interest,
+        gc_startdate=start_time,
+        gc_enddate=end_time,
         xlim=[-180, 180],
         ylim=[-90, 90],
         gc_cache=os.path.join(config["workDir"], "gc_run", "OutputDir"),
         build_jacobian=False,  # Not relevant
         period_i=False,  # Not relevant
-        config=False,
-    )  # Not relevant
+        config=False,  # Not relevent
+    )
 
     return result["obs_GC"], filename
 
 
-def create_daily_means(satelliteDir, start_time_of_interest, end_time_of_interest):
+def create_daily_means(satelliteDir, start_time, end_time):
 
-    # List of all TROPOMI files that interesct our time period of interest
+    # List of all TROPOMI files that intersect our time period of interest
     TROPOMI_files = sorted(
         [
             file
             for file in glob.glob(os.path.join(satelliteDir, "*.nc"))
-            if (
-                start_time_of_interest
-                <= get_TROPOMI_times(file)[0]
-                <= end_time_of_interest
-            )
-            or (
-                start_time_of_interest
-                <= get_TROPOMI_times(file)[1]
-                <= end_time_of_interest
-            )
+            if (start_time <= get_TROPOMI_times(file)[0] <= end_time)
+            or (start_time <= get_TROPOMI_times(file)[1] <= end_time)
         ]
     )
     print(f"First TROPOMI file -> {TROPOMI_files[0]}")
@@ -104,9 +90,7 @@ def create_daily_means(satelliteDir, start_time_of_interest, end_time_of_interes
         LAT = data["lat"].values
 
     # List of all days in our time range of interest
-    alldates = np.arange(
-        start_time_of_interest, end_time_of_interest, dtype="datetime64[D]"
-    )
+    alldates = np.arange(start_time, end_time, dtype="datetime64[D]")
     alldates = [day.astype(datetime.datetime).strftime("%Y%m%d") for day in alldates]
 
     # Initialize arrays for regridding
@@ -126,9 +110,7 @@ def create_daily_means(satelliteDir, start_time_of_interest, end_time_of_interes
             # Which day are we on (this is not perfect right now because orbits can cross from one day to the next...
             # but it is the best we can do right now without changing apply_tropomi_operator)
             file_times = re.search(r"(\d{8}T\d{6})_(\d{8}T\d{6})", filename)
-            assert (
-                file_times is not None
-            ), "check TROPOMI filename - wasn't able to find start and end times in the filename"
+            assert file_times is not None
             try:
                 date = datetime.datetime.strptime(file_times.group(1), "%Y%m%dT%H%M%S").strftime("%Y%m%d")
                 time_ind = alldates.index(date)
@@ -312,13 +294,13 @@ if __name__ == "__main__":
     blendedTROPOMI = sys.argv[1] == "True"  # use blended data?
     satelliteDir = sys.argv[2]  # where is the satellite data?
     # Start of GC output (+1 day except 1 Apr 2018 because we ran 1 day extra at the start to account for data not being written at t=0)
-    start_time_of_interest = np.datetime64(
+    start_time = np.datetime64(
         datetime.datetime.strptime(sys.argv[3], "%Y%m%d")
     )
-    if start_time_of_interest != np.datetime64("2018-04-01T00:00:00"):
-        start_time_of_interest += np.timedelta64(1, "D")
+    if start_time != np.datetime64("2018-04-01T00:00:00"):
+        start_time += np.timedelta64(1, "D")
     # End of GC output
-    end_time_of_interest = np.datetime64(
+    end_time = np.datetime64(
         datetime.datetime.strptime(sys.argv[4], "%Y%m%d")
     )
     print(f"\nwrite_boundary_conditions.py output for blendedTROPOMI={blendedTROPOMI}")
@@ -340,8 +322,6 @@ if __name__ == "__main__":
         - using the bias from Part 2, subtract the (GC-TROPOMI) bias from the GC boundary conditions
     """
 
-    daily_means = create_daily_means(
-        satelliteDir, start_time_of_interest, end_time_of_interest
-    )
+    daily_means = create_daily_means(satelliteDir, start_time, end_time)
     bias = calculate_bias(daily_means)
     write_bias_corrected_files(bias)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Describe the update

Currently, we remove our smoothed column bias equally from all 47 vertical layers of the originally simulated mixing ratio profiles:
```
new_gc_mixing_ratio = original_gc_mixing_ratio - bias
```
Instead, I now scale the originally simulated mixing ratio profiles:
```
new_gc_xch4 = original_gc_xch4 - bias
new_gc_mixing_ratio = original_gc_mixing_ratio * (new_gc_xch4 / original_gc_xch4)
```
The impact isn't large, but I believe this is a more realistic strategy at high bias values. See below for global average profiles for 2019–2024 with the old and new method, the difference between these profiles, and finally the spatial differences that result from going from GEOS-Chem 14.4.1 to 14.6.2 (mostly the reversion from EDGAR v8 to v7 livestock + the update to GFEIv3 are visible).

![profile-comp](https://github.com/user-attachments/assets/6615ccf9-4929-443e-b33b-fe96a2c49861)
![profile-diff](https://github.com/user-attachments/assets/993428e1-a42c-4c0f-b51f-3d842fe2ada2)
![spatial](https://github.com/user-attachments/assets/dce70feb-1cd8-4969-ba97-866afb900792)