### PR TITLE
Fix file handling to speed up inversion for large-region or long-period runs

### DIFF
--- a/src/inversion_scripts/jacobian.py
+++ b/src/inversion_scripts/jacobian.py
@@ -8,6 +8,7 @@ import re
 import os
 import datetime
 import yaml
+import gc
 from src.inversion_scripts.utils import save_obj
 from src.inversion_scripts.operators.TROPOMI_operator import (
     apply_average_tropomi_operator,
@@ -195,6 +196,11 @@ if __name__ == "__main__":
             print("Saving .pkl file")
             save_obj(output, f"{outputdir}/{date}_GCtoTROPOMI.pkl")
             save_obj(viz_output, f"{vizdir}/{date}_GCtoTROPOMI.pkl")
+        
+        #Clean up to reduce memory use
+        del output, viz_output
+        gc.collect()
+
         return 0
 
     results = Parallel(n_jobs=-1)(delayed(process)(filename) for filename in sat_files)


### PR DESCRIPTION
# Name and Institution

Name: Sabour Baray
Institution: Environment and Climate Change Canada

## Explanation of the issue
For large regions or long time periods, the jacobian.py step within the inversion workflow tends to be memory intensive, sluggish, or fail to complete. The workaround has been to allocate less CPUs and more memory per worker during [parallel processing of satellite files](https://github.com/geoschem/integrated_methane_inversion/blob/2c926e53d6f32dda10b06e8fb6c6fc19a82b93e5/src/inversion_scripts/jacobian.py#L140). However the process tends to slow down over the course of a run, indicating memory or performance issues. On the ECCC HPC a 1-year inversion in the Permian basin (20190101 to 20200101) using the custom shapefile will not complete the jacobian.py step when given maximum InversionMemory available on our system per job (180 GB).

## Solution
This PR shows an easy fix to the [concat_tracers()](https://github.com/geoschem/integrated_methane_inversion/blob/2c926e53d6f32dda10b06e8fb6c6fc19a82b93e5/src/inversion_scripts/operators/operator_utilities.py#L169) function. To my knowledge, this function contains the only example in this parallel processing step where xarray is called without a context manager wrapping the opening and closing of the file in a _with_ block:

[operator_utilities.py L200](https://github.com/geoschem/integrated_methane_inversion/blob/2c926e53d6f32dda10b06e8fb6c6fc19a82b93e5/src/inversion_scripts/operators/operator_utilities.py#L200)
```
        dsmf = xr.open_dataset("/".join([j_dir, file_stub]), chunks="auto")
```

This file may remain open longer than needed, leading to excessive open file handles and delayed memory cleanup.

Additionally, cleaning up large objects at the end of each parallel iteration could help in [jacobian.py L194](https://github.com/geoschem/integrated_methane_inversion/blob/2c926e53d6f32dda10b06e8fb6c6fc19a82b93e5/src/inversion_scripts/jacobian.py#L194):
```
        if output["obs_GC"].shape[0] > 0:
            print("Saving .pkl file")
            save_obj(output, f"{outputdir}/{date}_GCtoTROPOMI.pkl")
            save_obj(viz_output, f"{vizdir}/{date}_GCtoTROPOMI.pkl")

        #Clean up to reduce memory use
        del output, viz_output
        gc.collect()

        return 0
```

## Testing

For the out-of-the-box 1-week Permian inversion, here are the runtime statistics (seconds):

#### Runtime Comparison (1-week Permian Test Case)

| Step      | Before (s) | After (s) |
|---------- |----------------- |--------------- |
| Setup     | 259              | 232            |
| Spinup    | 711              | 821            |
| Jacobian  | 252              | 244            |
| Inversion | 72               | 52             |
| Posterior | 257              | 246            |


The impact on the inversion step (72s vs. 52s) could be small for smaller domains and shorter time periods.

For a larger domain setup (custom-shapefile Permian) and longer time period (1-year 2019), on our machines this fix allows the run to complete when it would get stuck otherwise.