### PR TITLE
bugfix for KF perturbation factor calculation

### DIFF
--- a/src/components/jacobian_component/make_perturbation_sf.py
+++ b/src/components/jacobian_component/make_perturbation_sf.py
@@ -148,8 +148,6 @@ def calculate_perturbation_sfs(
     # also scales the jacobian calculation to account for the nudged prior emissions
     effective_pert_sf = (jacobian_pert_sf - 1) / flat_prior_sf
 
-    effective_pert_sf = effective_pert_sf - 1.0
-
     # return dictionary of perturbation scale factor arrays
     perturbation_dict = {
         "effective_pert_sf": effective_pert_sf,

--- a/src/components/jacobian_component/make_perturbation_sf.py
+++ b/src/components/jacobian_component/make_perturbation_sf.py
@@ -144,9 +144,10 @@ def calculate_perturbation_sfs(
         flat_prior_sf = np.ones(len(jacobian_pert_sf))
 
     # calculate the effective perturbation SFs
-    effective_pert_sf = jacobian_pert_sf / flat_prior_sf
+    # this will be a fraction relative to 0 and in the case of a Kalman filter
+    # also scales the jacobian calculation to account for the nudged prior emissions
+    effective_pert_sf = (jacobian_pert_sf - 1) / flat_prior_sf
 
-    # make the effective perturbations relative to 0, as expected in the inversion
     effective_pert_sf = effective_pert_sf - 1.0
 
     # return dictionary of perturbation scale factor arrays


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
This bugfix properly generates the `effective_pert_sf`for calculation of the Jacobian. This change only affects the Kalman Filter IMI mode because the `effective_pert_sf` also needs to account for scaling the Jacobian according to the nudged prior emissions from the previous period.

Thanks, Matt Thill, for finding this and @eastjames for helping to think it through.