### PR TITLE
Update HEMCO standalone output to files generated with HEMCO 3.11.1 and GEOS-Chem 14.6.2 emissions

### DIFF
--- a/src/components/statevector_component/statevector.sh
+++ b/src/components/statevector_component/statevector.sh
@@ -23,7 +23,7 @@ create_statevector() {
     LandCoverFile="${DataPath}/${LandCoverSuffix}"
 
     # Use archived HEMCO standalone emissions output
-    HemcoDiagFile="${DataPath}/HEMCO/CH4/v2024-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.${gridFile}.2023.nc"
+    HemcoDiagFile="${DataPath}/HEMCO/CH4/v2025-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.${gridFile}.2023.nc"
     
     # Download land cover and HEMCO diagnostics files
     # if the files do not exist
@@ -32,7 +32,7 @@ create_statevector() {
         python ${InversionPath}/src/utilities/download_aws_file.py ${s3_lc_path} ${LandCoverFile}
     fi
     if [ ! -f "$HemcoDiagFile" ]; then
-        s3_hd_path="s3://gcgrid/HEMCO/CH4/v2024-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.${gridFile}.2023.nc"
+        s3_hd_path="s3://gcgrid/HEMCO/CH4/v2025-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.${gridFile}.2023.nc"
         python ${InversionPath}/src/utilities/download_aws_file.py ${s3_hd_path} ${HemcoDiagFile}
     fi
 

--- a/src/notebooks/statevector_from_shapefile.ipynb
+++ b/src/notebooks/statevector_from_shapefile.ipynb
@@ -370,7 +370,7 @@
     ")\n",
     "hemco_diag_file = f\"HEMCO_sa_diagnostics.{gridRes}.2023.nc\"\n",
     "hemco_diag_pth = (\n",
-    "    f'{config[\"DataPath\"]}/HEMCO/CH4/v2024-07/HEMCO_SA_Output/{hemco_diag_file}'\n",
+    "    f'{config[\"DataPath\"]}/HEMCO/CH4/v2025-07/HEMCO_SA_Output/{hemco_diag_file}'\n",
     ")"
    ]
   },

--- a/src/utilities/utils.py
+++ b/src/utilities/utils.py
@@ -73,7 +73,7 @@ def download_hemcodiags_files(config):
         gridFile = "025x03125"
 
     s3_hd_path = (
-        f"HEMCO/CH4/v2024-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.{gridFile}.2023.nc"
+        f"HEMCO/CH4/v2025-07/HEMCO_SA_Output/HEMCO_sa_diagnostics.{gridFile}.2023.nc"
     )
     HemcoDiagFile = os.path.join(config["DataPath"], s3_hd_path)
     target_dir = os.path.dirname(HemcoDiagFile)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The HEMCO standalone output were updated to include the latest emission updates now in GEOS-Chem 14.6.2. This includes

- Updating the bottom-up global CH4 oil, gas, and coal emissions to GFEI v3
- Updating rice emissions to the Global Rice Paddy Inventory (GRPI)
- Fixes for seasonality of hydropower reservoir and livestock emissions