### PR TITLE
account for multiple processings with different versions

### DIFF
--- a/src/utilities/download_TROPOMI.py
+++ b/src/utilities/download_TROPOMI.py
@@ -17,7 +17,7 @@ from botocore.client import Config
 #     $ python download_TROPOMI.py 20190101 20190214 TROPOMI_data
 
 s3 = None
-VALID_TROPOMI_PROCESSOR_VERSIONS = ["020400", "020500", "020600"]
+VALID_TROPOMI_PROCESSOR_VERSIONS = ["020400", "020500", "020600", "020701", "020800"]
 
 
 def initialize_boto3():
@@ -114,6 +114,11 @@ def get_s3_paths(start_date, end_date, bucket):
     # If there are multiple processor versions for the same orbit number,
     # keep the one with the latest version.
     df = df.loc[df.groupby("OrbitNumber")["ProcessorVersion"].idxmax()]
+    df.reset_index(drop=True, inplace=True)
+
+    # For the final duplicates, choose the later modification date
+    df["ModificationDate"] = pd.to_datetime(df["ModificationDate"])
+    df = df.loc[df.groupby("OrbitNumber")["ModificationDate"].idxmax()]
     df.reset_index(drop=True, inplace=True)
         
     assert len(df) == len(df["OrbitNumber"].unique())


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
As reported in #345, sometimes TROPOMI orbits are processed with two different processor versions. This bugfix ensures that only the file using the latest processor is downloaded.