### PR TITLE
Switch to total emissions and use mean to remove time dimension

### DIFF
--- a/src/utilities/make_state_vector_file.py
+++ b/src/utilities/make_state_vector_file.py
@@ -166,7 +166,7 @@ def make_state_vector_file(
         lc = np.round( -(lc/100.-1), decimals=5)
     else:
         lc = (lc["FRLAKE"] + lc["FRLAND"] + lc["FRLANDIC"]).drop_vars("time").squeeze()
-    hd = (hd["EmisCH4_Oil"] + hd["EmisCH4_Gas"]).drop_vars("time").squeeze()
+    hd = hd["EmisCH4_Total"].mean(dim="time")
 
     # Check compatibility of region of interest
     if is_regional:


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
This fixes a bug with using the latest HEMCO_SA_output files used to generate the state vector. The update removes the time dimension from the hemco emissions files by taking the mean for all time steps. This was previously not an issue because the hemco files only had a single time step. We also switch to using Total emissions instead of just oil and gas emissions to decide whether to include an offshore grid cell in the state vector