### PR TITLE
Filter out permanent snow/ice scenes

### DIFF
--- a/src/inversion_scripts/operators/TROPOMI_operator.py
+++ b/src/inversion_scripts/operators/TROPOMI_operator.py
@@ -779,6 +779,9 @@ def read_blended(filename):
             dat["surface_classification"] = (
                 blended_data["surface_classification"].values[:].astype("uint8") & 0x03
             ).astype(int)
+            dat["surface_classification_0xF9"] = (
+                blended_data["surface_classification"].values[:].astype("uint8") & 0xF9
+                ).astype(int)
             dat["chi_square_SWIR"] = blended_data["chi_square_SWIR"].values[:]
 
             # Remove "Z" from time so that numpy doesn't throw a warning

--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -501,6 +501,7 @@ def filter_blended(blended_data, xlim, ylim, startdate, enddate, use_water_obs=F
                 & (blended_data["chi_square_SWIR"][:] > 20000)
             )
         )
+        & ~(blended_data["surface_classification_0xF9"] == 184)
         & (blended_data["latitude"] > -60)
     )
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Megan He
Institution: Harvard ACMG

### Describe the update

This PR excludes scenes over permanent ice surfaces (e.g. Greenland) by reading in an additional TROPOMI surface classification mask called 0xF9 and filtering out the observations if the `surface_classification == 184` for snow/ice. See [here](https://sentinels.copernicus.eu/documents/247904/2474726/Sentinel-5P-Level-2-Product-User-Manual-Methane.pdf) for reference.