### PR TITLE
fix perturbation calculation to properly account for delta x

### DIFF
--- a/src/components/jacobian_component/make_perturbation_sf.py
+++ b/src/components/jacobian_component/make_perturbation_sf.py
@@ -91,9 +91,8 @@ def calculate_perturbation_sfs(
         effective_pert_sf [array]: contains the perturbation scalefactors (based on the
                                    nudged prior emissions for kalman mode) used in the
                                    inversion to calculate the sensitivity of observations
-                                   to the perturbation. These are relative to 0, so a 50%
-                                   perturbation is represented as 0.5. For a standalone
-                                   inversion, effective_pert_sf + 1 == jacobian_pert_sf.
+                                   to the perturbation. In standalone mode this will be the same
+                                   as jacobian_pert_sf.
 
         target_emission   [float]: the target emission value used to calculate the perturbation
     """
@@ -144,9 +143,10 @@ def calculate_perturbation_sfs(
         flat_prior_sf = np.ones(len(jacobian_pert_sf))
 
     # calculate the effective perturbation SFs
-    # this will be a fraction relative to 0 and in the case of a Kalman filter
-    # also scales the jacobian calculation to account for the nudged prior emissions
-    effective_pert_sf = (jacobian_pert_sf - 1) / flat_prior_sf
+    # this will be the same as the jacobian perturbation SFs
+    # for a standalone inversion, but for kalman mode is scaled
+    # to account for the nudged prior emissions
+    effective_pert_sf = jacobian_pert_sf / flat_prior_sf
 
     # return dictionary of perturbation scale factor arrays
     perturbation_dict = {


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
This reverts a bugfix in our jacobian calculation that was incorrectly applied in PR #290. 

To calculate each column of the jacobian, we do the following: 

$$K_i = \frac{\Delta xch_4}{\Delta x_i}$$

In PR #290, we mistakenly assumed:

$$\Delta xch_4 = F(x_i \* perturbationSF) -  F(x)$$

This implies that:

$$\Delta x_i = perturbationSF - 1$$

In this formulation, a perturbationSF of 1.5 (meaning a 50% upward perturbation) would have a $\Delta x_i = 0.5$.

However, this overlooks a change in PR #275, where we updated the Jacobian simulations to **zero out emissions in all grid cells except for the one being perturbed** (i.e., the element of interest $x_i$ ). This change was intended to reduce advection noise in the Jacobian.

Given that update, the $\Delta xch_4$ is represented as:

$$\Delta xch_4 = F(x_i \* perturbationSF) -  F(x \* 0),$$

where:
- $F(x_i \* perturbationSF)$ represents the model output when only the i-th element is perturbed (all others are zero)
- $F(x \* 0)$ is the simulation with zero emissions everywhere.

In this case:

$$\Delta x_i = perturbationSF$$

Here, a $perturbationSF$ of 1.5 would have a $\Delta x_i = 1.5$.

This correction should have minimal impact on inversion results overall, since most $perturbationSF$ values are quite large (on the order of 10s–1000s). However, it will have a **larger relative effect in grid cells with large emissions**, where the Jacobian sensitivity is more significant.
