### PR TITLE
Update configuration files to use blended TROPOMI observations and boundary conditions

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,7 +13,7 @@ EndDate: 20180508
 SpinupMonths: 1
 
 ## Use blended TROPOMI+GOSAT data (true)? Or use operational TROPOMI data (false)?
-BlendedTROPOMI: false
+BlendedTROPOMI: true
 
 ## Use observations over water? Set to false to filter out water observations
 UseWaterObs: false
@@ -207,12 +207,12 @@ RestartDownload: true
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/home/ubuntu/ExtData/BoundaryConditions/v2025-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/home/ubuntu/ExtData/BoundaryConditions/v2025-06-blended/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
 BCpath: "/home/ubuntu/ExtData/BoundaryConditions"
-BCversion: "v2025-06"
+BCversion: "v2025-06-blended"
 
 ## Options to download missing GEOS-Chem input data from AWS S3
 HemcoPriorEmisDryRun: true

--- a/envs/Harvard-Cannon/config.harvard-cannon.12km.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.12km.yml
@@ -13,7 +13,7 @@ EndDate: 20230101
 SpinupMonths: 1
 
 ## Use blended TROPOMI+GOSAT data (true)? Or use operational TROPOMI data (false)?
-BlendedTROPOMI: false
+BlendedTROPOMI: true
 
 ## Use observations over water? Set to false to filter out water observations
 UseWaterObs: false
@@ -198,7 +198,7 @@ OutputPath: "/n/holylfs06/LABS/jacob_lab2/Lab/$USER"
 DataPath: "/n/holylfs06/LABS/jacob_lab/Everyone/GEOS-CHEM/gcgrid/gcdata/ExtData"
 
 ## Path to TROPOMI Data
-DataPathTROPOMI: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi"
+DataPathTROPOMI: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended"
 
 ## Conda environment file
 ## See envs/README to create the Conda environment specified below
@@ -215,11 +215,11 @@ RestartDownload: false
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
-BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions"
+BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended-boundary-conditions"
 BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3

--- a/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
@@ -13,7 +13,7 @@ EndDate: 20180502
 SpinupMonths: 1
 
 ## Use blended TROPOMI+GOSAT data (true)? Or use operational TROPOMI data (false)?
-BlendedTROPOMI: false
+BlendedTROPOMI: true
 
 ## Use observations over water? Set to false to filter out water observations
 UseWaterObs: false
@@ -198,7 +198,7 @@ OutputPath: "/n/holylfs06/LABS/jacob_lab2/Lab/$USER"
 DataPath: "/n/holylfs06/LABS/jacob_lab/Everyone/GEOS-CHEM/gcgrid/gcdata/ExtData"
 
 ## Path to TROPOMI Data
-DataPathTROPOMI: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi"
+DataPathTROPOMI: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended"
 
 ## Conda environment file
 ## See envs/README to create the Conda environment specified below
@@ -215,11 +215,11 @@ RestartDownload: false
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
-BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions"
+BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended-boundary-conditions"
 BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3

--- a/envs/Harvard-Cannon/config.harvard-cannon.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.yml
@@ -13,7 +13,7 @@ EndDate: 20180508
 SpinupMonths: 1
 
 ## Use blended TROPOMI+GOSAT data (true)? Or use operational TROPOMI data (false)?
-BlendedTROPOMI: false
+BlendedTROPOMI: true
 
 ## Use observations over water? Set to false to filter out water observations
 UseWaterObs: false
@@ -198,7 +198,7 @@ OutputPath: "/n/holylfs06/LABS/jacob_lab2/Lab/$USER"
 DataPath: "/n/holylfs06/LABS/jacob_lab/Everyone/GEOS-CHEM/gcgrid/gcdata/ExtData"
 
 ## Path to TROPOMI Data
-DataPathTROPOMI: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi"
+DataPathTROPOMI: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended"
 
 ## Conda environment file
 ## See envs/README to create the Conda environment specified below
@@ -215,11 +215,11 @@ RestartDownload: false
 
 ## Path to initial GEOS-Chem restart file + prefix
 ##   ("YYYYMMDD_0000z.nc4" will be appended)
-RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
+RestartFilePrefix: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended-boundary-conditions/v2025-06/GEOSChem.BoundaryConditions."
 
 ## Path to GEOS-Chem boundary condition files (for regional simulations)
 ## BCversion will be appended to the end of this path. ${BCpath}/${BCversion}
-BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/tropomi-boundary-conditions"
+BCpath: "/n/holylfs05/LABS/jacob_lab/imi/ch4/blended-boundary-conditions"
 BCversion: "v2025-06"
 
 ## Options to download missing GEOS-Chem input data from AWS S3


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The blended TROPOMI+GOSAT product described in [Balasus et al. (2023)](https://amt.copernicus.org/articles/16/3787/2023/) is now recommended as the default product for use in the IMI. This option was originally introduced in IMI 2.0 as documented in [Estrada et al. (2025)](https://gmd.copernicus.org/articles/18/3311/2025/). The default configuration file (`config.yml`) and envs/Harvard-Cannon configuration files have been updated to reflect this recommendation. The configuration files have also been updated to use the blended boundary condition files for consistency with the observational dataset used.