### PR TITLE
Fix error in imi_preview for estimating computing cost and averaging kernel sensitivity

### DIFF
--- a/src/components/preview_component/preview.sh
+++ b/src/components/preview_component/preview.sh
@@ -45,14 +45,14 @@ run_preview() {
             -t $RequestedTime \
             -p $SchedulerPartition \
             -o imi_output.tmp \
-            -W $preview_file $InversionPath $ConfigPath $state_vector_path $preview_dir $tropomi_cache
+            -W $preview_file $ConfigPath $state_vector_path $preview_dir $tropomi_cache
         wait
         cat imi_output.tmp >>${InversionPath}/imi_output.log
         rm imi_output.tmp
         # check for any errors
         [ ! -f ".preview_error_status.txt" ] || imi_failed $LINENO
     else
-        python $preview_file $InversionPath $ConfigPath $state_vector_path $preview_dir $tropomi_cache
+        python $preview_file $ConfigPath $state_vector_path $preview_dir $tropomi_cache
     fi
     printf "\n=== DONE RUNNING IMI PREVIEW ===\n"
 

--- a/src/inversion_scripts/jacobian.py
+++ b/src/inversion_scripts/jacobian.py
@@ -118,8 +118,8 @@ if __name__ == "__main__":
         datetime.datetime.strptime(end, "%Y-%m-%d %H:%M:%S")
         - datetime.timedelta(days=1)
     )
-    print("Start:", start)
-    print("End:", end)
+    print("Start:", gc_startdate)
+    print("End:", gc_enddate)
 
     # Get TROPOMI data filenames for the desired date range
     allfiles = glob.glob(f"{tropomi_cache}/*.nc")


### PR DESCRIPTION
### Name and Institution (Required)

Name: Dandan Zhang
Institution: Harvard University

### Describe the update

- In imi_preview.py, the inversion area cannot be calculated correctly with [the function](https://github.com/geoschem/integrated_methane_inversion/blob/main/src/inversion_scripts/imi_preview.py#L171) used there. Instead, an alternate method of estimating number of grid box is used as implemented in [src/inversion_scripts/imi_preview.py](https://github.com/geoschem/integrated_methane_inversion/pull/337/files#diff-f40c1bfd264189b9d4ee3f03c2a48806fb96f2e2029f02520e32a755c8ebf9ec). This will fix the error stated in https://github.com/geoschem/integrated_methane_inversion/issues/331 for the cost estimation in imi_preview.py.
- Fix the error for calculating averaging kernel density as well as stated in https://github.com/geoschem/integrated_methane_inversion/issues/331.
- Additionally, the message printed out for TROPOMI file time range would be one day more, and thus confusing. Fix it accordingly.