### PR TITLE
Fix date string in geoschem_config.yml for 12km runs

### DIFF
--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -78,8 +78,13 @@ setup_template() {
     cp ${InversionPath}/src/utilities/download_gc_data.py download_gc_data.py
 
     # Modify geoschem_config.yml based on settings in config.yml
-    sed -i -e "s:20190101:${StartDate}:g" \
-        -e "s:20190201:${EndDate}:g" geoschem_config.yml
+    if [ "$Res" == "0.125x0.15625" ]; then
+	sed -i -e "s:20230101:${StartDate}:g" \
+               -e "s:20230201:${EndDate}:g" geoschem_config.yml
+    else
+	sed -i -e "s:20190101:${StartDate}:g" \
+               -e "s:20190201:${EndDate}:g" geoschem_config.yml
+    fi
 
     if "$isRegional"; then
         # Adjust lat/lon bounds because GEOS-Chem defines the domain


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The default date string in template_run/geoschem_config.yml for CH4 runs was 20190101. This is not the case for 12km runs though because fields at that resolution are not available until mid-2021. When users set up a 12km GEOS-Chem run directory, the date in geoschem_config.yml is set to 20230101 by default.

The code in template.sh has been updated to look for the correct date string based on grid resolution and replace it with the start and end dates as defined in the IMI config file.