### PR TITLE
Fix state vector file generation to only include offshore grid boxes when oil/gas emissions are non-zero

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -3,6 +3,7 @@
 #SBATCH -N 1
 #SBATCH -c 1
 #SBATCH --mem=2000
+#SBATCH --mail-type=END
 #SBATCH -o "imi_output.log"
 
 # This script will run the Integrated Methane Inversion (IMI) with GEOS-Chem.

--- a/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
+++ b/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
@@ -82,8 +82,7 @@ run_hemco_prior_emis() {
     # Modify HEMCO files based on settings in config.yml
     sed -i -e "/DiagnFreq:           00000100 000000/d" \
         -e "/Negative values:     0/d" HEMCO_sa_Config.rc
-    sed -i -e "s/METEOROLOGY            :       true/METEOROLOGY            :       false/g" \
-        -e "s|DiagnFreq:                   End|DiagnFreq:                   Daily|g" HEMCO_Config.rc
+    sed -i -e "s/METEOROLOGY            :       true/METEOROLOGY            :       false/g" HEMCO_Config.rc
     sed -i -e "/#SBATCH -c 8/d" runHEMCO.sh
     sed -i -e "/#SBATCH -t 0-12:00/d" runHEMCO.sh
     sed -i -e "/#SBATCH -p huce_intel/d" runHEMCO.sh

--- a/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
+++ b/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
@@ -9,6 +9,15 @@
 # Usage:
 #   run_hemco_prior_emis
 run_hemco_prior_emis() {
+
+    # Ensure a template run directory exists
+    if [[ ! -d ${RunDirs}/template_run ]]; then
+        printf "\n A template run directory is required for running the HEMCO standalone simulation to generate prior emissions. Generating one now.\n"
+	runDir="template_run"
+	RunTemplate="${RunDirs}/${runDir}"
+        setup_template
+    fi
+
     hemco_prior_emis_start=$(date +%s)
     
     HEMCOdir="hemco_prior_emis"

--- a/src/components/preview_component/preview.sh
+++ b/src/components/preview_component/preview.sh
@@ -12,7 +12,7 @@ run_preview() {
     # First run the HEMCO standalone if necessary to get prior emissions
     # needed for prepare_sf.py
     if [[ ! -d ${RunDirs}/hemco_prior_emis/OutputDir ]]; then
-        printf "\hemco_prior_emis directory not detected. Running HEMCO for prior emissions as a prerequisite for IMI Preview.\n"
+        printf "\n hemco_prior_emis directory not detected. Running HEMCO for prior emissions as a prerequisite for IMI Preview.\n"
         run_hemco_prior_emis
     fi
 

--- a/src/components/setup_component/setup.sh
+++ b/src/components/setup_component/setup.sh
@@ -133,9 +133,15 @@ setup_imi() {
     if "$CreateAutomaticRectilinearStateVectorFile"; then
         create_statevector
     else
-        # Copy custom state vector to $RunDirs directory for later use
-        printf "\nCopying state vector file\n"
-        cp -v $StateVectorFile ${RunDirs}/StateVector.nc
+	if [ ! -f "$StateVectorFile" ]; then
+	    printf "\nERROR: Cannot find ${StateVectorFile}"
+            printf "\n Please fix StateVectorFile or set CreateAutomaticRectilinearStateVectorFile: true in config.yml\n"
+            exit 1
+	else
+	    # Copy custom state vector to $RunDirs directory for later use
+            printf "\nCopying state vector file\n"
+            cp -v $StateVectorFile ${RunDirs}/StateVector.nc
+	fi
     fi
 
     # Determine number of elements in state vector file

--- a/src/components/statevector_component/statevector.sh
+++ b/src/components/statevector_component/statevector.sh
@@ -56,6 +56,14 @@ create_statevector() {
 # Usage:
 #   reduce_dimension
 reduce_dimension() {
+
+    # First run the HEMCO standalone if necessary to get prior emissions
+    # needed for prepare_sf.py
+    if [[ ! -d ${RunDirs}/hemco_prior_emis/OutputDir ]]; then
+        printf "\n hemco_prior_emis directory not detected. Running HEMCO for prior emissions as a prerequisite for reducing dimensions of state vector.\n"
+        run_hemco_prior_emis
+    fi
+
     printf "\n=== REDUCING DIMENSION OF STATE VECTOR FILE ===\n"
 
     # set input variables

--- a/src/utilities/make_state_vector_file.py
+++ b/src/utilities/make_state_vector_file.py
@@ -166,7 +166,10 @@ def make_state_vector_file(
         lc = np.round( -(lc/100.-1), decimals=5)
     else:
         lc = (lc["FRLAKE"] + lc["FRLAND"] + lc["FRLANDIC"]).drop_vars("time").squeeze()
-    hd = hd["EmisCH4_Total"].mean(dim="time")
+
+    # Save total emissions and oil/gas separately for handling offshore emissions
+    hd_og = (hd["EmisCH4_Oil"] + hd["EmisCH4_Gas"]).mean(dim="time")
+    hd    = hd["EmisCH4_Total"].mean(dim="time")
 
     # Check compatibility of region of interest
     if is_regional:
@@ -214,11 +217,11 @@ def make_state_vector_file(
         statevector[:, (statevector.lon < lon_min) | (statevector.lon > lon_max)] = 0
         statevector[(statevector.lat < lat_min) | (statevector.lat > lat_max), :] = 0
 
-    # Also set pixels over water to 0, unless there are offshore emissions
+    # Also set pixels over water to 0, unless there are offshore oil/gas emissions
     if land_threshold > 0:
         # Where there is neither land nor emissions, replace with 0
         if is_regional:
-            land = lc.where((lc > land_threshold) | (hd > emis_threshold))
+            land = lc.where((lc > land_threshold) | (hd_og > emis_threshold))
         else:
             # handle half-width polar grid boxes for global,
             # global files are same shape but different lat
@@ -228,10 +231,10 @@ def make_state_vector_file(
                 & np.equal(hd.lat.shape, lc.lat.shape).all()
             ):
                 land = lc.where(
-                    (lc.values > land_threshold) | (hd.values > emis_threshold)
+                    (lc.values > land_threshold) | (hd_og.values > emis_threshold)
                 )
             else:
-                land = lc.where((lc > land_threshold) | (hd > emis_threshold))
+                land = lc.where((lc > land_threshold) | (hd_og > emis_threshold))
 
         statevector.values[land.isnull().values] = -9999
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

In PR #348, we switched from using oil+gas emissions to total emissions when generating the state vector netCDF file. This inadvertently includes more ocean grid boxes than needed because some emission sectors include non-zero emissions over oceans simply because they have been regridded from coarse resolution (e.g. 4x5 for termites) datasets. To resolve this, the code has been updated to only include offshore emissions grid boxes where oil+gas emissions are non-zero.

This PR also includes other minor fixes and error checks:

- Add checks to make sure template run directories and HEMCO standalone run directory exist when needed
- Add check to make sure state vector file exists when the create state vector option is turned off
- Update HEMCO prior emissions run to save out single diagnostic file containing average emissions for the inversion period, rather than daily files
- Update IMI run script to send the user an email when the entire IMI job has completed (when submitting via SLURM)


Example StateVector.nc file over Algeria before the fix:

<img width="875" height="578" alt="Screenshot 2025-09-24 at 10 39 09 AM" src="https://github.com/user-attachments/assets/c0492ffc-73d1-4f14-ae1a-49f01a58d930" />

after the fix:

<img width="887" height="572" alt="Screenshot 2025-09-24 at 10 36 53 AM" src="https://github.com/user-attachments/assets/defd953f-15dc-46cb-801f-2d1c0fe49089" />

