### PR TITLE
Revert HEMCO prior emissions output to `Daily` instead of `End`

### DIFF
--- a/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
+++ b/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
@@ -82,7 +82,8 @@ run_hemco_prior_emis() {
     # Modify HEMCO files based on settings in config.yml
     sed -i -e "/DiagnFreq:           00000100 000000/d" \
         -e "/Negative values:     0/d" HEMCO_sa_Config.rc
-    sed -i -e "s/METEOROLOGY            :       true/METEOROLOGY            :       false/g" HEMCO_Config.rc
+    sed -i -e "s/METEOROLOGY            :       true/METEOROLOGY            :       false/g" \
+           -e "s|DiagnFreq:                   End|DiagnFreq:                   Daily|g" HEMCO_Config.rc
     sed -i -e "/#SBATCH -c 8/d" runHEMCO.sh
     sed -i -e "/#SBATCH -t 0-12:00/d" runHEMCO.sh
     sed -i -e "/#SBATCH -p huce_intel/d" runHEMCO.sh


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

In https://github.com/geoschem/integrated_methane_inversion/pull/367/files, I had changed the HEMCO prior emissions run to output a single file at the end of the run. It turns out we should be saving out daily files so that the jacobian simulations can input total daily emissions.