### PR TITLE
Minor math corrections to lognormal_invert

### DIFF
--- a/src/inversion_scripts/lognormal_invert.py
+++ b/src/inversion_scripts/lognormal_invert.py
@@ -151,7 +151,7 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
         # the lognormal part of K gets scaled by prior_scale to convert to median
         K_ROI = K_temp[:, :-num_normal_elems]
         K_normal = K_temp[:, -num_normal_elems:]
-        K_ROI = prior_scale * K_ROI
+        K_ROI = K_ROI / prior_scale
         K_full = np.concatenate((K_ROI, K_normal), axis=1)
 
         m, n = np.shape(K_ROI)
@@ -159,7 +159,8 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
         # Create base xa and lnxa matrices
         # Note: the resulting xa vector has lognormal elements until the
         # final Buffer, BCs, and OH elements
-        xa = np.ones((n, 1)) * 1.0
+        # Convert to median before calculating lnxa
+        xa = np.ones((n, 1)) * prior_scale
         lnxa = np.log(xa)
 
         # Create normal elements for buffer, BCs, and OH
@@ -295,7 +296,7 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
         dlns = np.diag(lns[:-num_normal_elems, :-num_normal_elems])
         xnmean = np.concatenate(
             (
-                xn[:-num_normal_elems]
+                ( xn[:-num_normal_elems] / xa[:-num_normal_elems] )
                 * np.expand_dims(np.exp(dlns * (0.5)) * prior_scale, axis=1),
                 xn[-num_normal_elems:],
             )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Matt Loman
Institution: University of Rochester

### Describe the update

I've made a couple edits to lognormal_invert.py that I think are necessary to get the math working properly.
- The `prior_scale` variable is $e^{\frac{-s'}{2}}$, the scaling factor applied to $x_{mean}$ to convert to $x_{median}$ in equation (5) of [Hancock et al., 2025](doi.org/10.5194/acp-25-797-2025). Since $K=\partial y/\partial x$, `K_ROI` should be divided by `prior_scale`, rather than multiplied, so that it represents $\partial y/\partial x_{median}$.
- In order for `(y_ybkg_diff - K_full @ xn)` on line 263 to represent the difference between the observations and (when `xn=xa`) the prior run, the lognormal part of `xn` needs to be a median to agree with $K_{ROI}=\partial y/\partial x_{median}$ above, so `xa` needs `prior_scale` applied.
- Finally, since we're no longer treating both $x_{a,mean}$ and $x_{a,median}$ as vectors of ones, the calculation of `xnmean` needs to be updated based on equation (6) of [Hancock et al., 2025](https://acp.copernicus.org/articles/25/797/2025/).

I haven't had a chance to run simulations to compare results, so please let me know if that will be necessary before merging.