### PR TITLE
Add fixes to netCDF output files and visualization notebook for ensemble mode

### DIFF
--- a/docs/source/advanced/inversion-ensemble.rst
+++ b/docs/source/advanced/inversion-ensemble.rst
@@ -7,40 +7,38 @@ can easily be reused for additional  inversions. This can be useful for understa
 sensitivity of the inversion results to the choice of prior error, observation error, 
 or other inversion parameters.
 
-The IMI has multiple options for creating an inversion ensemble.
-
-1. **Automated ensemble generation**:
+Automated ensemble generation
+-----------------------------
 
 The simplest way to generate an ensemble is to run the IMI a single time with
-a configuration file that specifies vectors of the desired range of hyperparameters (eg.`PriorError: [0.5, 0.75]`). 
+a configuration file that specifies vectors of the desired range of hyperparameters (e.g. ``PriorError: [0.5, 0.75]``). 
 The IMI will then run multiple inversions with the various combinations of hyperparameter values. Each ensemble member is
-saved to the `inversion_results_ensemble.nc` and `gridded_posterior_ensemble.nc` file. The ensemble member used for the posterior simulation
-is saved to the `inversion_results.nc` and `gridded_posterior.nc` files. This method is useful for quickly generating an ensemble without
+saved to the ``inversion_results_ensemble.nc`` and ``gridded_posterior_ensemble.nc`` file. This method is useful for quickly generating an ensemble without
 having to manually run the IMI multiple times with new run directories and configuration files. However, vectors can only be
-applied for the following hyperparameters: `PriorError`, `ObsError`, `Gamma`, `PriorErrorBCs`, `PriorErrorBufferElements`, 
-`PriorErrorOH`.
+applied for the following hyperparameters: ``PriorError``, ``ObsError``, ``Gamma``, ``PriorErrorBCs``, ``PriorErrorBufferElements``, 
+``PriorErrorOH``.
 
-In the ensemble result files (`inversion_results_ensemble.nc` and `gridded_posterior_ensemble.nc`), an additional coordinate is included that
+In the ensemble result files (``inversion_results_ensemble.nc`` and ``gridded_posterior_ensemble.nc``), an additional coordinate is included that
 allows selection of the inversion results for each ensemble member. In python, this can be done as follows:
 
-```python
-import xarray as xr
-ds = xr.open_dataset('inversion_results_ensemble.nc')
-# select the inversion results for ensemble member 2
-ensemble_member_2 = ds.sel(ensemble=2)
+.. code-block:: console
+    
+    python
+    import xarray as xr
+    ds = xr.open_dataset('inversion_results_ensemble.nc')
+    # select the inversion results for ensemble member 2
+    ensemble_member_2 = ds.sel(ensemble=2)
 
-# print the hyperparameters used for ensemble member 2
-params = ["prior_err", "obs_err", "gamma", "prior_err_bc", "prior_err_oh"]
-for param in params:
-    print(f"{param}: {ensemble_member_2[param]}")
-```
-The data variables in the default result files (`inversion_results.nc` and `gridded_posterior.nc`) are the inversion results
-from the ensemble member that most  closely matches the expected output of the chi-square distribution (:math:`J_a / n \approx 1`) (Lu et al., 2021), 
-where :math:`n` is the number of state vector elements. This result is used for the posterior simulation and, if using Kalman Mode, is the ensemble member 
-that propogates into the next inversion.
+    # print the hyperparameters used for ensemble member 2
+    params = ["prior_err", "obs_err", "gamma", "prior_err_bc", "prior_err_oh"]
+    for param in params:
+        print(f"{param}: {ensemble_member_2[param]}")
+
+The output used for the posterior simulation is saved to the ``inversion_results.nc`` and `gridded_posterior.nc``` files.  
+The data in these files represents the mean of the ensemble members.
 
 Choosing ensemble members:
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 The IMI will generate all possible combinations of the hyperparameters specified in the configuration file regardless
 of whether some combinations are unrealistic. For example, if you tighten the prior error to a value that is
@@ -48,11 +46,15 @@ very low (eg. 0.01) and weight the observations very highly via the regularizati
 have little freedom to update the emissions and would return the prior emissions despite the heavy weighting of the observations.
 Therefore, it is important to carefully choose which ensemble members to include in the ensemble analysis. Several visualizations
 come built into the visualization notebook that can help users identify which ensemble members are realistic. Once identified, 
-unrealistic `ensemble_members` can be removed from the uncertainty analysis. Another metric that can be used to identify unrealistic
-ensemble members is the `chi-square` metric. This metric is saved in the inversion_results.nc file and is a measure of how well the
+unrealistic ensemble members can be removed from the uncertainty analysis. 
+
+Another metric that can be used to identify unrealistic ensemble members is the `chi-square` metric. This metric is saved in the ``inversion_results.nc`` file and is a measure of how well the
 inversion results match the expected output of the chi-square distribution (:math:`J_a / n \approx 1`). Ideally, this value should be
 close to 1. If the `chi-square` value is much greater (or less) than 1, it is likely that the inversion results are not realistic and the 
 ensemble member should be removed from the uncertainty analysis.
+
+**By default, the IMI filters ensemble members such that the ensemble only includes members with (:math:`J_a / n = 0.5-2.0`).** 
+This filtering can be modified or turned off by changing the ``filter_ens_members`` settings in the ``invert.py`` and ``lognormal_invert.py`` scripts.    
 
 The visualization notebook creates the following figures to analyze the ensemble spread and sensitivity of the inversion results to the hyperparameters:
 
@@ -71,13 +73,16 @@ In this example, you can see from the second figure that the inversion results a
 is too low or too high can lead to unrealistic inversion results. Here, we see that the gamma value of 0.1 is too low, causing the inversion to return the prior emissions. 
 In this case, it would be reasonable to remove the ensemble members with low gamma from the uncertainty analysis.
 
-2. **Manual ensemble generation**:
+Manual ensemble generation
+--------------------------
+
 In this scenario, you have already run your base inversion. You can then use the IMI to create an ensemble of inversions
 by specifying a new run directory that references the precomputed Jacobian matrix from the base run directory.
 This method is useful for generating an ensemble with inputs that cannot be specified as vectors in the configuration
 file. For example, you may want to run an ensemble of sensitivity inversions that swap out prior emission inventories, 
-or use Lognormal instead of Gaussian prior error distributions. Note: When applying state vector clustering you cannot 
-use the precomputed Jacobian if you swap out prior emissions inventories. This is because the underlying distribution of 
+or use Lognormal instead of Gaussian prior error distributions. 
+
+Note: When applying state vector clustering you cannot use the precomputed Jacobian if you swap out prior emissions inventories. This is because the underlying distribution of 
 emissions within individual state vector clusters may change, requiring a new Jacobian matrix to be computed.
 
 See the `Common configurations page <../other/common-configurations.html#running-a-sensitivity-inversion>`__ 

--- a/src/inversion_scripts/invert.py
+++ b/src/inversion_scripts/invert.py
@@ -467,10 +467,38 @@ def do_inversion_ensemble(
     # closest to 1 as the default member
     dataset.attrs = {"default_member_index": idx_default_Ja}
 
+    # Specify attributes
+    dataset.xhat.attrs["long_name"] = "Posterior scaling factors"
+    dataset.xhat.attrs["units"] = "1"
+    dataset.S_post.attrs["long_name"] = "Posterior error covariance matrix"
+    dataset.S_post.attrs["units"] = "1"  
+    dataset.A.attrs["long_name"] = "Averaging kernel matrix"
+    dataset.A.attrs["units"] = "1"
+    dataset.DOFS.attrs["long_name"] = "Degrees of freedom for signal"
+    dataset.DOFS.attrs["units"] = "1"
+    dataset.Ja_normalized.attrs["long_name"] = "Normalized cost function Ja/n"
+    dataset.Ja_normalized.attrs["units"] = "1"
+    dataset.prior_err.attrs["long_name"] = "Prior error (Sa)"
+    dataset.prior_err.attrs["units"] = "1"
+    dataset.obs_err.attrs["long_name"] = "Observation error (So)"
+    dataset.obs_err.attrs["units"] = "ppb"
+    dataset.gamma.attrs["long_name"] = "Regularization parameter"
+    dataset.gamma.attrs["units"] = "1"
+    dataset.prior_err_bc.attrs["long_name"] = "Prior error for BC elements"
+    dataset.prior_err_bc.attrs["units"] = "ppb"
+    dataset.prior_err_oh.attrs["long_name"] = "Prior error for OH elements"
+    dataset.prior_err_oh.attrs["units"] = "1"
+    dataset.KTinvSoK.attrs["long_name"] = "K^T * inv(So) * K expression from inversion equation"
+    dataset.KTinvSoK.attrs["units"] = "1"
+    dataset.KTinvSoyKxA.attrs["long_name"] = "K^T * inv(So) * (y-K*xA) expression from inversion equation"
+    dataset.KTinvSoyKxA.attrs["units"] = "1"
+    dataset.ratio.attrs["long_name"] = "Change from prior (xhat - xA)"
+    dataset.ratio.attrs["units"] = "1"
+
     # ensemble dimension to end
     dataset = dataset.transpose(..., "ensemble")
 
-    # also calculate the mean of the ensemble as the main result
+    # Calculate the mean of the ensemble as the main result
     dataset_mean = dataset.mean(dim="ensemble")
 
     return dataset, dataset_mean

--- a/src/inversion_scripts/lognormal_invert.py
+++ b/src/inversion_scripts/lognormal_invert.py
@@ -332,6 +332,10 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
 
     # Define the default data variables as those with normalized Ja closest to 1
     idx_default_Ja = np.argmin(np.abs(np.array(results_dict["Ja_normalized"]) - 1))
+    print(
+        f"J_A/n closest to 1: {results_dict['Ja_normalized'][idx_default_Ja]} with"
+        + f" (prior_err, obs_err, gamma, prior_err_bc, prior_err_oh) = {hyperparam_ensemble[idx_default_Ja]}"
+    )
 
     # Filter ensemble members to only members with Ja between 0.5 and 2
     filter_ens_members = True  # set to False to turn off filtering
@@ -371,7 +375,33 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
     # ensemble dimension to end
     dataset = dataset.transpose(..., "ensemble")
 
-    # also calculate the mean of the ensemble as the main result
+    # Specify attributes
+    dataset.xhat.attrs["long_name"] = "Posterior scaling factors"
+    dataset.xhat.attrs["units"] = "1"
+    dataset.lnxn.attrs["long_name"] = "Posterior log scaling factors"
+    dataset.lnxn.attrs["units"] = "1"
+    dataset.S_post.attrs["long_name"] = "Posterior error covariance matrix"
+    dataset.S_post.attrs["units"] = "1"  
+    dataset.A.attrs["long_name"] = "Averaging kernel matrix"
+    dataset.A.attrs["units"] = "1"
+    dataset.DOFS.attrs["long_name"] = "Degrees of freedom for signal"
+    dataset.DOFS.attrs["units"] = "1"
+    dataset.Ja_normalized.attrs["long_name"] = "Normalized cost function Ja/n"
+    dataset.Ja_normalized.attrs["units"] = "1"
+    dataset.prior_err.attrs["long_name"] = "Prior error (Sa)"
+    dataset.prior_err.attrs["units"] = "1"
+    dataset.obs_err.attrs["long_name"] = "Observation error (So)"
+    dataset.obs_err.attrs["units"] = "ppb"
+    dataset.gamma.attrs["long_name"] = "Regularization parameter"
+    dataset.gamma.attrs["units"] = "1"
+    dataset.prior_err_bc.attrs["long_name"] = "Prior error for BC elements"
+    dataset.prior_err_bc.attrs["units"] = "ppb"
+    dataset.prior_err_oh.attrs["long_name"] = "Prior error for OH elements"
+    dataset.prior_err_oh.attrs["units"] = "1"
+    dataset.prior_err_buffer.attrs["long_name"] = "Prior error for buffer elements"
+    dataset.prior_err_buffer.attrs["units"] = "1"
+
+    # Calculate the mean of the ensemble as the main result
     dataset_mean = dataset.mean(dim="ensemble")
 
     dataset.to_netcdf(

--- a/src/inversion_scripts/make_gridded_posterior.py
+++ b/src/inversion_scripts/make_gridded_posterior.py
@@ -96,8 +96,9 @@ def make_gridded_posterior(posterior_SF_path, state_vector_path, save_path):
         encoding={v: {"zlib": True, "complevel": 1} for v in ds.data_vars}
     )
 
-    # Create netcdf for default results
-    ds.isel(ensemble = ds.attrs['default_member_index']).to_netcdf(
+    # Calculate the mean of the ensemble as the main result
+    ds_mean = ds.mean(dim="ensemble")
+    ds_mean.to_netcdf(
         save_path,
         encoding={v: {"zlib": True, "complevel": 1} for v in ds.data_vars}
     )

--- a/src/notebooks/visualization_notebook.ipynb
+++ b/src/notebooks/visualization_notebook.ipynb
@@ -224,7 +224,10 @@
    "source": [
     "# Prior emissions\n",
     "prior_ds = get_mean_emissions(start_date, end_date, prior_cache)\n",
-    "prior = prior_ds[\"EmisCH4_Total\"]\n",
+    "if config[\"OptimizeSoil\"]:\n",
+    "    prior = prior_ds[\"EmisCH4_Total\"]\n",
+    "else:\n",
+    "    prior = prior_ds[\"EmisCH4_Total_ExclSoilAbs\"]\n",
     "\n",
     "if config[\"KalmanMode\"]:\n",
     "    # properly apply nudged sfs to prior in Kalman mode\n",
@@ -242,7 +245,10 @@
     "\n",
     "# Posterior emissions\n",
     "posterior_ds = get_posterior_emissions(prior_ds, scale_ds, config[\"OptimizeSoil\"])\n",
-    "posterior = posterior_ds[\"EmisCH4_Total\"]"
+    "if config[\"OptimizeSoil\"]:\n",
+    "    posterior = posterior_ds[\"EmisCH4_Total\"]\n",
+    "else:\n",
+    "    posterior = posterior_ds[\"EmisCH4_Total_ExclSoilAbs\"]"
    ]
   },
   {
@@ -284,7 +290,7 @@
     "\n",
     "    ens_totals_posterior = np.array(\n",
     "        [\n",
-    "            sum_total_emissions(item[\"EmisCH4_Total\"], areas, mask)\n",
+    "            sum_total_emissions(item[\"EmisCH4_Total_ExclSoilAbs\"], areas, mask)\n",
     "            for item in ensemble_posteriors\n",
     "        ]\n",
     "    )\n",


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The code in `lognormal_invert.py` has been fixed to now save out the mean of ensemble members to the `inversion_result_ln.nc` file. This is now consistent with updates made in https://github.com/geoschem/integrated_methane_inversion/pull/361. The code in `lognormal_invert.py` and `invert.py` has also been updated to specify the `long_name` attribute for fields saved out to the netCDF files. Documentation for the ensemble option has been updated to clarify that the ensemble mean is used for the posterior simulation.

Additionally, the visualization notebook has been updated to sum and plot the `EmisCH4_Total_ExclSoilAbs` when comparing the ensemble members and the ensemble mean vs the prior. Previously, `EmisCH4_Total` was used which includes the soil sink flux and therefore made the total emissions value appear lower than it actually is.