### PR TITLE
Bug fixes: Remove time dimension from state vector dataset reads to avoid errors

### DIFF
--- a/src/components/jacobian_component/make_perturbation_sf.py
+++ b/src/components/jacobian_component/make_perturbation_sf.py
@@ -199,8 +199,8 @@ def make_perturbation_sf(config, period_number, perturb_value=1e-8):
         hemco_emis = get_mean_emissions(start_date, end_date, prior_cache)
         prior_sf = None
 
-    # load the state vector dataset
-    state_vector = xr.load_dataset(os.path.join(base_directory, "StateVector.nc"))
+    # load the state vector dataset and squeeze time dimension
+    state_vector = xr.load_dataset(os.path.join(base_directory, "StateVector.nc")).squeeze()
 
     # calculate the perturbation scale factors we perturb each state vector element by
     perturbation_dict = calculate_perturbation_sfs(

--- a/src/inversion_scripts/make_gridded_posterior.py
+++ b/src/inversion_scripts/make_gridded_posterior.py
@@ -44,7 +44,7 @@ def make_gridded_posterior(posterior_SF_path, state_vector_path, save_path):
     """
 
     # Load state vector and inversion results data
-    statevector = xr.load_dataset(state_vector_path)
+    statevector = xr.load_dataset(state_vector_path).squeeze()
     inv_results = xr.load_dataset(posterior_SF_path)
 
     target_data_prefixes = ["xhat", "S_post", "A"]

--- a/src/notebooks/visualization_notebook.ipynb
+++ b/src/notebooks/visualization_notebook.ipynb
@@ -135,7 +135,7 @@
     "else:\n",
     "    state_vector_filepath = \"./../StateVector.nc\"\n",
     "\n",
-    "state_vector = xr.open_dataset(state_vector_filepath)\n",
+    "state_vector = xr.open_dataset(state_vector_filepath).squeeze()\n",
     "state_vector_labels = state_vector[\"StateVector\"]\n",
     "\n",
     "# Identify the last element of the region of interest\n",


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

In PR #362, time was added as a dimension the state vector netCDF file for compatibility with GCHP. This causes errors in a few routines that read the state vector file because they are not expecting the additional dimension. Here, we utilize the squeeze function to remove the time (dimension=1) when loading the state vector dataset.