### PR TITLE
Corrected bug utils.py

### DIFF
--- a/src/inversion_scripts/utils.py
+++ b/src/inversion_scripts/utils.py
@@ -125,7 +125,7 @@ def check_is_BC_element(sv_elem, nelements, opt_OH, opt_BC, is_OH_element, is_re
         not is_OH_element
         and opt_BC
         and (
-            (opt_OH and (sv_elem > (nelements - 6)))
+            (opt_OH and not(is_regional) and (sv_elem > (nelements - 6)))
             or (opt_OH and is_regional and (sv_elem > (nelements - 5)))
             or ((not opt_OH) and (sv_elem > (nelements - 4)))
         )


### PR DESCRIPTION
correcting a bug in check_is_BC_elements in inversion_scripts/utils.py: if opt_OH and is_regional are both True, we want to add 5 elements at the end of the state vector.  However, not checking for not(is_regional) in the first condition of the OR combination makes it such that the code directly expects 6 from the first condition in the is_regional=True and opt_OH=True case, instead of 5.

### Name and Institution (Required)

Name: Matthieu Dogniaux
Institution: SRON

### Describe the update

See above