### PR TITLE
Update GEOS-Chem run directories to use carbon simulation instead of the CH4 simulation

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -145,7 +145,7 @@ MaxSimultaneousRuns: -1
 ##   Specifying a value = 1 will submit a separate jacobian simulation for each
 ##   state vector element. Specifying a value > 1 will combine state vector
 ##   elements into a single jacobian simulation.
-NumJacobianTracers: 5
+NumJacobianTracers: 1
 
 ##====================================================================
 ##

--- a/envs/Harvard-Cannon/config.harvard-cannon.12km.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.12km.yml
@@ -145,7 +145,7 @@ MaxSimultaneousRuns: -1
 ##   Specifying a value = 1 will submit a separate jacobian simulation for each
 ##   state vector element. Specifying a value > 1 will combine state vector
 ##   elements into a single jacobian simulation.
-NumJacobianTracers: 5
+NumJacobianTracers: 1
 
 ##====================================================================
 ##

--- a/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.global_inv.yml
@@ -145,7 +145,7 @@ MaxSimultaneousRuns: -1
 ##   Specifying a value = 1 will submit a separate jacobian simulation for each
 ##   state vector element. Specifying a value > 1 will combine state vector
 ##   elements into a single jacobian simulation.
-NumJacobianTracers: 5
+NumJacobianTracers: 1
 
 ##====================================================================
 ##

--- a/envs/Harvard-Cannon/config.harvard-cannon.yml
+++ b/envs/Harvard-Cannon/config.harvard-cannon.yml
@@ -145,7 +145,7 @@ MaxSimultaneousRuns: -1
 ##   Specifying a value = 1 will submit a separate jacobian simulation for each
 ##   state vector element. Specifying a value > 1 will combine state vector
 ##   elements into a single jacobian simulation.
-NumJacobianTracers: 5
+NumJacobianTracers: 1
 
 ##====================================================================
 ##

--- a/envs/MSU-HPC_Orion/config.msu-hpc_orion.global_inv.yml
+++ b/envs/MSU-HPC_Orion/config.msu-hpc_orion.global_inv.yml
@@ -145,7 +145,7 @@ MaxSimultaneousRuns: -1
 ##   Specifying a value = 1 will submit a separate jacobian simulation for each
 ##   state vector element. Specifying a value > 1 will combine state vector
 ##   elements into a single jacobian simulation.
-NumJacobianTracers: 5
+NumJacobianTracers: 1
 
 ##====================================================================
 ##

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -123,7 +123,8 @@ create_simulation_dir() {
     else
         RestartFile=${RestartFilePrefix}${StartDate}_0000z.nc4
         if "$UseBCsForRestart"; then
-            sed -i -e "s|SpeciesRst|SpeciesBC|g" HEMCO_Config.rc
+            sed -i -e "s|SpeciesRst|SpeciesBC|g" \
+                   -e "s|EFYO|CYS|g" HEMCO_Config.rc
         fi
     fi
     ln -s $RestartFile Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -256,7 +256,14 @@ create_simulation_dir() {
                 HcoNextLineMask='* HEMIS_MASK $ROOT\/MASKS\/v2024-08\/hemisphere_mask.01x01.nc Hemisphere 2000\/1\/1\/0 C xy 1 * - 1 1 
 '
                 sed -i "/${HcoPrevLineMask}/a ${HcoNextLineMask}" HEMCO_Config.rc
-            fi
+
+		# Add zero scale factor
+		HcoPrevLineSF='1 NEGATIVE -1.0 - - - xy 1 1'
+                HcoNextLineSF='5 ZERO      0.0 - - - xy 1 1
+'
+                sed -i "/${HcoPrevLineSF}/a ${HcoNextLineSF}" HEMCO_Config.rc
+
+	    fi
         fi
 
         # If the current state vector element is one of the BC state vector elements, then

--- a/src/components/osse_component/osse_sim.sh
+++ b/src/components/osse_component/osse_sim.sh
@@ -84,7 +84,8 @@ setup_osse() {
         RestartFile=${RestartFilePrefix}${StartDate}_0000z.nc4
         ln -sfn $RestartFile Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
         if "$UseBCsForRestart"; then
-            sed -i -e "s|SpeciesRst|SpeciesBC|g" HEMCO_Config.rc
+            sed -i -e "s|SpeciesRst|SpeciesBC|g" \
+                   -e "s|EFYO|CYS|g" HEMCO_Config.rc
             printf "\nWARNING: Changing restart field entry in HEMCO_Config.rc to read the field from a boundary condition file. Please revert SpeciesBC_ back to SpeciesRst_ for subsequent runs.\n"
         fi
     fi

--- a/src/components/posterior_component/posterior.sh
+++ b/src/components/posterior_component/posterior.sh
@@ -40,7 +40,8 @@ setup_posterior() {
         RestartFile=${RestartFilePrefix}${StartDate}_0000z.nc4
         ln -s $RestartFile Restarts/GEOSChem.Restart.${StartDate}_0000z.nc4
         if "$UseBCsForRestart"; then
-            sed -i -e "s|SpeciesRst|SpeciesBC|g" HEMCO_Config.rc
+            sed -i -e "s|SpeciesRst|SpeciesBC|g" \
+                   -e "s|EFYO|CYS|g" HEMCO_Config.rc
             printf "\nWARNING: Changing restart field entry in HEMCO_Config.rc to read the field from a boundary condition file. Please revert SpeciesBC_ back to SpeciesRst_ for subsequent runs.\n"
         fi
     fi

--- a/src/components/posterior_component/posterior.sh
+++ b/src/components/posterior_component/posterior.sh
@@ -73,8 +73,8 @@ setup_posterior() {
         sed -i -e 's/#'\''LevelEdgeDiags/'\''LevelEdgeDiags/g' \
             -e 's/LevelEdgeDiags.frequency:   00000100 000000/LevelEdgeDiags.frequency:   00000000 010000/g' \
             -e 's/LevelEdgeDiags.duration:    00000100 000000/LevelEdgeDiags.duration:    00000001 000000/g' \
-            -e 's/Restart.frequency:          '\''End'\''/Restart.frequency:          00000001 000000/g' \
-            -e 's/Restart.duration:           '\''End'\''/Restart.duration:           00000001 000000/g' HISTORY.rc
+            -e 's/Restart.frequency:    00000100 000000/Restart.frequency:    00000001 000000/g' \
+            -e 's/Restart.duration:     00000100 000000/Restart.duration:     00000001 000000/g' HISTORY.rc
     fi
 
     ### Turn on observation operators if requested, for posterior run

--- a/src/components/spinup_component/spinup.sh
+++ b/src/components/spinup_component/spinup.sh
@@ -36,7 +36,8 @@ setup_spinup() {
     RestartFile=${RestartFilePrefix}${SpinupStart}_0000z.nc4
     ln -s $RestartFile Restarts/GEOSChem.Restart.${SpinupStart}_0000z.nc4
     if "$UseBCsForRestart"; then
-        sed -i -e "s|SpeciesRst|SpeciesBC|g" HEMCO_Config.rc
+        sed -i -e "s|SpeciesRst|SpeciesBC|g" \
+               -e "s|EFYO|CYS|g" HEMCO_Config.rc
         printf "\nWARNING: Changing restart field entry in HEMCO_Config.rc to read the field from a boundary condition file. Please revert SpeciesBC_ back to SpeciesRst_ for subsequent runs.\n"
     fi
 

--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -25,7 +25,26 @@ setup_template() {
         exit 9999
     fi
 
-    # Commands to feed to createRunDir.sh
+    #---------------------------------------------------------------------
+    # Create GEOS-Chem run directory 
+    #---------------------------------------------------------------------
+    simNum=3  # Carbon simulation
+
+    # Species
+    spcNum=2  # Hardcode for now; enable options below when CO2 is supported
+    #if [[ "$Species" == "CH4" ]]; then
+    #	spcNum=2
+    #elif [[ "$Species" == "CO2" ]]; then
+    #	spcNum=3
+    #elif [[ "$Species" == "CH4_CO2" ]]; then
+    #	spcNum=1
+    #else
+    #	printf "\nERROR: Species ${Species} is not supported by the IMI. "
+    #	printf "\n Options are CH4, CO2, or CH4_CO2"
+    #	exit 1
+    #fi
+
+    # Meteorology field
     if [[ "$Met" == "MERRA2" || "$Met" == "MERRA-2" || "$Met" == "merra2" ]]; then
         metNum="1"
     elif [[ "$Met" == "GEOSFP" || "$Met" == "GEOS-FP" || "$Met" == "geosfp" ]]; then
@@ -36,35 +55,36 @@ setup_template() {
         printf "\n Options are GEOSFP or MERRA2.\n"
         exit 1
     fi
-    if [ "$Res" = "4.0x5.0" ]; then
-        cmd="9\n${metNum}\n1\n2\n${RunDirs}\n${runDir}\nn\n"
-    elif [ "$Res" == "2.0x2.5" ]; then
-        cmd="9\n${metNum}\n2\n2\n${RunDirs}\n${runDir}\nn\n"
-    elif [ "$Res" == "0.5x0.625" ]; then
-        if "$isRegional"; then
-            # Use NA domain by default and adjust lat/lon below
-            cmd="9\n${metNum}\n3\n4\n2\n${RunDirs}\n${runDir}\nn\n"
-        else
-            cmd="9\n${metNum}\n3\n1\n2\n${RunDirs}\n${runDir}\nn\n"
-        fi
-    elif [ "$Res" == "0.25x0.3125" ]; then
-        if "$isRegional"; then
-            # Use NA domain by default and adjust lat/lon below
-            cmd="9\n${metNum}\n4\n4\n2\n${RunDirs}\n${runDir}\nn\n"
-        else
-            cmd="9\n${metNum}\n4\n1\n2\n${RunDirs}\n${runDir}\nn\n"
-        fi
-    elif [ "$Res" == "0.125x0.15625" ]; then
-        if "$isRegional"; then
-            # Use NA domain by default and adjust lat/lon below
-            cmd="9\n${metNum}\n5\n4\n2\n${RunDirs}\n${runDir}\nn\n" #regional run
-        else
-            cmd="9\n${metNum}\n5\n1\n2\n${RunDirs}\n${runDir}\nn\n"
-        fi
+
+    # Grid resolution
+    if [[ "$Res" == "4.0x5.0" ]]; then
+        resNum=1
+    elif [[ "$Res" == "2.0x2.5" ]]; then
+        resNum=2
+    elif [[ "$Res" == "0.5x0.625" ]]; then
+	resNum=3
+    elif [[ "$Res" == "0.25x0.3125" ]]; then
+	resNum=4
+    elif [[ "$Res" == "0.125x0.15625" ]]; then
+	resNum=5
     else
         printf "\nERROR: Grid resolution ${Res} is not supported by the IMI. "
         printf "\n Options are 0.125x0.15625, 0.25x0.3125, 0.5x0.625, 2.0x2.5, or 4.0x5.0.\n"
         exit 1
+    fi
+
+    # Regional or global
+    if "$isRegional"; then
+	regionNum=4  # Use NA domain by default and adjust lat/lon below
+    else
+	regionNum=1
+    fi
+
+    # Command to feed to createRunDir.sh
+    if [[ "$Res" == "4.0x5.0" || "$Res" == "2.0x2.5" ]]; then
+	cmd="${simNum}\n${spcNum}\n${metNum}\n${resNum}\n2\n${RunDirs}\n${runDir}\nn\n"
+    else
+	cmd="${simNum}\n${spcNum}\n${metNum}\n${resNum}\n${regionNum}\n2\n${RunDirs}\n${runDir}\nn\n"
     fi
 
     # Create run directory
@@ -72,6 +92,9 @@ setup_template() {
     rm -f createRunDir.log
     printf "\nCreated ${RunTemplate}\n"
 
+    #---------------------------------------------------------------------
+    # Modify default settings in run directory
+    #---------------------------------------------------------------------
     cd ${RunTemplate}
 
     # Copy download script to run directory
@@ -164,7 +187,9 @@ setup_template() {
     # Copy input file for applying emissions perturbations via HEMCO
     cp ${InversionPath}/src/geoschem_run_scripts/Perturbations.txt .
 
+    #---------------------------------------------------------------------
     # Compile GEOS-Chem and store executable in GEOSChem_build directory
+    #---------------------------------------------------------------------
     printf "\nCompiling GEOS-Chem...\n"
     cd build
     cmake ${InversionPath}/GCClassic >>build_geoschem.log 2>&1

--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -193,7 +193,7 @@ setup_template() {
     printf "\nCompiling GEOS-Chem...\n"
     cd build
     cmake ${InversionPath}/GCClassic >>build_geoschem.log 2>&1
-    cmake . -DRUNDIR=.. >>build_geoschem.log 2>&1
+    cmake . -DRUNDIR=.. -DMECH=carbon >>build_geoschem.log 2>&1
     make -j install >>build_geoschem.log 2>&1
     cd ..
     if [[ -f gcclassic ]]; then


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

In GEOS-Chem 14.7.0 we [retire the individual CH4, CO2, and tagCO simulations](https://github.com/geoschem/geos-chem/pull/2685) in favor of the carbon simulation, which may be run in single-species or joint-species mode. This requires us to update to the carbon simulation in the IMI. This PR makes the switch to use the CH4-only carbon simulation, which was shown to be produce identical model output as the CH4 simulation.

For the carbon simulation, chemistry is now done through KPP. Since KPP requires a mechanism file with predefined active species, this complicates grouping state vector elements into fewer simulations using "jacobian tracers."Therefore, we must hardcode the numJacobianTracers in config.yml to 1 for now. Once https://github.com/geoschem/geos-chem/pull/3080 is merged into GEOS-Chem, we should be able to modify that value again.