### PR TITLE
Update GEOS-Chem version to 14.7.1

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -143,7 +143,7 @@ mkdir -p -v ${RunDirs}
 
 # Set/Collect information about the GEOS-Chem version, IMI version,
 # and TROPOMI processor version
-GEOSCHEM_VERSION=14.7.0
+GEOSCHEM_VERSION=14.7.1
 IMI_VERSION=$(git describe --tags)
 TROPOMI_PROCESSOR_VERSION=$(grep 'VALID_TROPOMI_PROCESSOR_VERSIONS =' src/utilities/download_TROPOMI.py |
     sed 's/VALID_TROPOMI_PROCESSOR_VERSIONS = //' |


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

Update GEOS-Chem version (for GCClassic or GCHP) to 14.7.1. Updates in this version relevant to the IMI are:

- https://github.com/geoschem/geos-chem/pull/3080
- https://github.com/geoschem/geos-chem/pull/3194
- https://github.com/geoschem/geos-chem/pull/3223

This version update is also needed in order to merge in:

- https://github.com/geoschem/integrated_methane_inversion/pull/379