### PR TITLE
Only run make_perturbation_sf.py at runtime for KF inversion

### DIFF
--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -92,17 +92,13 @@ setup_jacobian() {
         sed -i -e "s:{JOBS}::g" jacobian_runs/submit_jacobian_simulations_array.sh
     fi
 
-    if "$KalmanMode"; then
-        jacobian_period=${period_i}
-    else
+    if ! "$KalmanMode"; then
         jacobian_period=1
+        # generate gridded perturbation values for all state vector elements
+        printf "\n=== GENERATE GRIDDED PERTURBATION SFs ===\n"
+        python ${InversionPath}/src/components/jacobian_component/make_perturbation_sf.py $ConfigPath $jacobian_period $PerturbValue
+        printf "\n=== DONE GENERATE GRIDDED PERTURBATION SFs ===\n"
     fi
-
-    set -e
-    # generate gridded perturbation values for all state vector elements
-    printf "\n=== GENERATE GRIDDED PERTURBATION SFs ===\n"
-    python ${InversionPath}/src/components/jacobian_component/make_perturbation_sf.py $ConfigPath $jacobian_period $PerturbValue
-    printf "\n=== DONE GENERATE GRIDDED PERTURBATION SFs ===\n"
 
     # Initialize (x=0 is base run, i.e. no perturbation; x=1 is state vector element=1; etc.)
     x=0

--- a/src/components/kalman_component/kalman.sh
+++ b/src/components/kalman_component/kalman.sh
@@ -121,9 +121,9 @@ run_period() {
     fi
 
     # Set dates in geoschem_config.yml for prior, perturbation, and posterior runs
-    python ${InversionPath}/src/components/kalman_component/change_dates.py $ConfigPath $StartDate_i $EndDate_i $RunDuration_i $UseGCHP $JacobianRunsDir
+    python ${InversionPath}/src/components/kalman_component/change_dates.py $ConfigPath $StartDate_i $EndDate_i $RunDuration_i $JacobianRunsDir
     wait
-    python ${InversionPath}/src/components/kalman_component/change_dates.py $ConfigPath $StartDate_i $EndDate_i $RunDuration_i $UseGCHP $PosteriorRunDir
+    python ${InversionPath}/src/components/kalman_component/change_dates.py $ConfigPath $StartDate_i $EndDate_i $RunDuration_i $PosteriorRunDir
     wait
     if ! "$UseGCHP"; then
         echo "Edited Start/End dates in geoschem_config.yml for prior/perturbed/posterior simulations: $StartDate_i to $EndDate_i"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
This fixes a bug where `make_perturbation_sf.py` fails to run if KalmanMode is turned on.
