### PR TITLE
bugfix in HEMCO_Config.rc for background simulation

### DIFF
--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -360,10 +360,10 @@ create_simulation_dir() {
                 -e "/)))MeMo_SOIL_ABSORPTION/a (((.not.UseTotalPriorEmis" HEMCO_Config.rc
         fi
 
-        # create a break in EMISSIONS logic block for MeMo in background simulation
-        if [[ "$x" = "background" ]]; then
-            sed -i -e "/(((MeMo_SOIL_ABSORPTION/i )))EMISSIONS" HEMCO_Config.rc
-            sed -i -e "/)))MeMo_SOIL_ABSORPTION/a (((EMISSIONS" HEMCO_Config.rc
+        # create a break in EMISSIONS and USE_CH4_DATA logic block for MeMo in background simulation
+        if [[ "$x" == "background" && "$OptimizeSoil" != true ]]; then
+            sed -i -e "/(((MeMo_SOIL_ABSORPTION/i )))USE_CH4_DATA\n)))EMISSIONS" HEMCO_Config.rc
+            sed -i -e "/)))MeMo_SOIL_ABSORPTION/a (((EMISSIONS\n(((USE_CH4_DATA" HEMCO_Config.rc
         fi
 
         if "$KalmanMode"; then

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -362,8 +362,12 @@ create_simulation_dir() {
 
         # create a break in EMISSIONS and USE_CH4_DATA logic block for MeMo in background simulation
         if [[ "$x" == "background" && "$OptimizeSoil" != true ]]; then
-            sed -i -e "/(((MeMo_SOIL_ABSORPTION/i )))USE_CH4_DATA\n)))EMISSIONS" HEMCO_Config.rc
-            sed -i -e "/)))MeMo_SOIL_ABSORPTION/a (((EMISSIONS\n(((USE_CH4_DATA" HEMCO_Config.rc
+            sed -i \
+                -e "/(((MeMo_SOIL_ABSORPTION/i )))EMISSIONS" \
+                -e "/(((MeMo_SOIL_ABSORPTION/i )))USE_CH4_DATA" HEMCO_Config.rc
+            sed -i \
+                -e "/)))MeMo_SOIL_ABSORPTION/a (((EMISSIONS" \
+                -e "/)))MeMo_SOIL_ABSORPTION/a (((USE_CH4_DATA" HEMCO_Config.rc
         fi
 
         if "$KalmanMode"; then

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -363,8 +363,8 @@ create_simulation_dir() {
         # create a break in EMISSIONS and USE_CH4_DATA logic block for MeMo in background simulation
         if [[ "$x" == "background" && "$OptimizeSoil" != true ]]; then
             sed -i \
-                -e "/(((MeMo_SOIL_ABSORPTION/i )))EMISSIONS" \
-                -e "/(((MeMo_SOIL_ABSORPTION/i )))USE_CH4_DATA" HEMCO_Config.rc
+                -e "/(((MeMo_SOIL_ABSORPTION/i )))USE_CH4_DATA" \
+                -e "/(((MeMo_SOIL_ABSORPTION/i )))EMISSIONS" HEMCO_Config.rc
             sed -i \
                 -e "/)))MeMo_SOIL_ABSORPTION/a (((EMISSIONS" \
                 -e "/)))MeMo_SOIL_ABSORPTION/a (((USE_CH4_DATA" HEMCO_Config.rc


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
Recent changes to the HEMCO_Config.rc file added a USE_CH4_DATA nested block that needs to be closed when including MeMo soil absorption in the background simulation. I also added an additional condition to the if statement that only excludes MeMo from the emissions block if soil absorption is not being optimized. This change only affects the lognormal inversion.

This error would previously pop up for the background simulation:
```
HEMCO ERROR: Closing bracket does not match opening bracket: EMISSIONS, 
expected: USE_CH4_DATA
 --> LOCATION: BracketCheck (hco_config_mod.F90)

HEMCO ERROR: Bracket error in HEMCO_Config.rc @ line )))EMISSIONS
 --> LOCATION: Config_ReadCont (hco_config_mod.F90)

HEMCO ERROR: Error in HEMCO_Config.rc @ section: ### BEGIN SECTION BASE EMISSIONS
 --> LOCATION: Config_ReadFile (hco_config_mod.F90)
```


Please provide a clear and concise overview of the update.