### PR TITLE
Miscellaneous bugfixes for Kalman filter inversion

### DIFF
--- a/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
+++ b/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
@@ -162,6 +162,7 @@ run_hemco_sa() {
     hemco_start=$1
     hemco_end=$2
     set -e
+    HEMCOdir="hemco_prior_emis"
 
     pushd ${RunDirs}/${HEMCOdir}
     # replace start and end times in HEMCO_sa_Time.rc

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -516,11 +516,14 @@ run_jacobian() {
         # generate gridded perturbation values for all state vector elements
         printf "\n=== GENERATE GRIDDED PERTURBATION SFs ===\n"
         python ${InversionPath}/src/components/jacobian_component/make_perturbation_sf.py $ConfigPath $jacobian_period $PerturbValue
-        cp ${RunDirs}/archive_perturbation_sfs/gridded_pert_scale_${period_i}.nc ${RunDirs}/gridded_perturbation_sf.nc
         printf "\n=== DONE GENERATE GRIDDED PERTURBATION SFs ===\n"
     else
         jacobian_period=1
     fi
+    set -e
+    # Copy the relevant gridded perturbation scale factor file to a generic name the Jacobian runs will look for
+    cp ${RunDirs}/archive_perturbation_sfs/gridded_pert_scale_${jacobian_period}.nc ${RunDirs}/gridded_perturbation_sf.nc
+    set +e
 
     pushd ${RunDirs}
 

--- a/src/components/jacobian_component/jacobian.sh
+++ b/src/components/jacobian_component/jacobian.sh
@@ -511,11 +511,12 @@ add_new_tracer() {
 # Usage:
 #   run_jacobian
 run_jacobian() {
-
     if "$KalmanMode"; then
         jacobian_period=${period_i}
+        # generate gridded perturbation values for all state vector elements
         printf "\n=== GENERATE GRIDDED PERTURBATION SFs ===\n"
         python ${InversionPath}/src/components/jacobian_component/make_perturbation_sf.py $ConfigPath $jacobian_period $PerturbValue
+        cp ${RunDirs}/archive_perturbation_sfs/gridded_pert_scale_${period_i}.nc ${RunDirs}/gridded_perturbation_sf.nc
         printf "\n=== DONE GENERATE GRIDDED PERTURBATION SFs ===\n"
     else
         jacobian_period=1

--- a/src/components/kalman_component/kalman.sh
+++ b/src/components/kalman_component/kalman.sh
@@ -169,7 +169,7 @@ run_period() {
     else
         org_restart=${PosteriorRunDir}/Restarts/GEOSChem.Restart.${EndDate_i}_0000z.nc4
     fi
-    python ${InversionPath}/src/components/jacobian_component/make_jacobian_icbc.py $ConfigPath $org_restart ${RunDirs}/jacobian_1ppb_ics_bcs/Restarts $EndDate_i $Species
+    python ${InversionPath}/src/components/jacobian_component/make_jacobian_icbc.py $ConfigPath $org_restart ${RunDirs}/jacobian_lowbg_ics_bcs/Restarts $EndDate_i $Species
     rundir_num=$(get_last_rundir_suffix $JacobianRunsDir)
     for ((idx = 0; idx <= rundir_num; idx++)); do
         # Add zeros to string name
@@ -197,13 +197,13 @@ run_period() {
         # Otherwise use the posterior simulation as the restart file
         if "$UseGCHP"; then
             if [[ "$filename" == *1ppb* ]]; then
-                ln -sf ${RunDirs}/jacobian_1ppb_ics_bcs/Restarts/GEOSChem.Restart.1ppb.${EndDate_i}_0000z.c${CS_RES}.nc4 ${JacobianRunsDir}/${RunName}_${idxstr}/Restarts/GEOSChem.Restart.${EndDate_i}_0000z.c${CS_RES}.nc4
+                ln -sf ${RunDirs}/jacobian_lowbg_ics_bcs/Restarts/GEOSChem.Restart.1ppb.${EndDate_i}_0000z.c${CS_RES}.nc4 ${JacobianRunsDir}/${RunName}_${idxstr}/Restarts/GEOSChem.Restart.${EndDate_i}_0000z.c${CS_RES}.nc4
             else
                 ln -sf ${PosteriorRunDir}/Restarts/GEOSChem.Restart.${EndDate_i}_0000z.c${CS_RES}.nc4 ${JacobianRunsDir}/${RunName}_${idxstr}/Restarts/.
             fi
         else
             if [[ "$filename" == *1ppb* ]]; then
-                ln -sf ${RunDirs}/jacobian_1ppb_ics_bcs/Restarts/GEOSChem.Restart.1ppb.${EndDate_i}_0000z.nc4 ${JacobianRunsDir}/${RunName}_${idxstr}/Restarts/GEOSChem.Restart.${EndDate_i}_0000z.nc4
+                ln -sf ${RunDirs}/jacobian_lowbg_ics_bcs/Restarts/GEOSChem.Restart.1ppb.${EndDate_i}_0000z.nc4 ${JacobianRunsDir}/${RunName}_${idxstr}/Restarts/GEOSChem.Restart.${EndDate_i}_0000z.nc4
             else
                 ln -sf ${PosteriorRunDir}/Restarts/GEOSChem.Restart.${EndDate_i}_0000z.nc4 ${JacobianRunsDir}/${RunName}_${idxstr}/Restarts/.
             fi

--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -170,7 +170,7 @@ setup_template() {
         jacobian_period=1
     fi
     scale_OLD=" ./gridded_pert_scale_1.nc"
-    scale_NEW=" ${RunDirs}/archive_perturbation_sfs/gridded_pert_scale_${jacobian_period}.nc"
+    scale_NEW=" ${RunDirs}/gridded_perturbation_sf.nc"
     sed -i -e "s@$scale_OLD@$scale_NEW@g" HEMCO_Config.rc
 
     if [ "$UseGCHP" = true ]; then

--- a/src/inversion_scripts/postproc_diags.py
+++ b/src/inversion_scripts/postproc_diags.py
@@ -95,7 +95,7 @@ def fill_missing_hour(run_name, run_dirs_pth, prev_run_pth, start_day, res):
         # Check if this is one of those simulations by checking if HEMCO_Config.rc
         # reads a 1ppb restart or BC file
         scale_to_1ppb = search_file(
-            f"{run_dirs_pth}/{r}/HEMCO_Config.rc", "jacobian_1ppb_ics_bcs"
+            f"{run_dirs_pth}/{r}/HEMCO_Config.rc", "jacobian_lowbg_ics_bcs"
         )
         if scale_to_1ppb:
             prev_data_SC["SpeciesConcVV_CH4"] = 0.0


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
This PR updates:
- directory names that were incorrect. This was missed because they are only used during the Kalman filter inversion. 
- The perturbations netcdf file was incorrectly being applied in the Kalman filter. This file is regenerated on each period of the Kalman filter and saved into `archive_perturbation_sfs/gridded_pert_scale_{period_number}.nc`. Here, I follow the same pattern as with the `ScaleFactors.nc file`, where we copy an active gridded perturbation file to the base run directory where the Jacobian simulations read that particular file.
