### PR TITLE
Fix clustering threshold bugs producing uneven clusters 

### DIFF
--- a/src/components/statevector_component/aggregation.py
+++ b/src/components/statevector_component/aggregation.py
@@ -532,10 +532,6 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
 
     print(f"Target DOFS per cluster (ClusteringThreshold): {dofs_threshold}")
 
-    # max cluster size based on user preferences
-    max_cluster_size = (
-        config["MaxClusterSize"] if "MaxClusterSize" in config.keys() else 64
-    )
     max_cluster_size = get_max_cluster_size(config, flat_sensi, desired_num_labels)
 
     try:
@@ -579,8 +575,6 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
 
     print(f"Reducing to {desired_num_labels} elements")
 
-    # total sensitivities of clusters added to the state vector
-    cluster_sensis = []
     # for each agg_level, cluster the data and assign the n_labels
     # with highest total sensitivity to the new label dataset
     for agg_level in cluster_pairs:

--- a/src/components/statevector_component/aggregation.py
+++ b/src/components/statevector_component/aggregation.py
@@ -144,6 +144,12 @@ def get_highest_labels_threshold(labels, sensitivities, threshold):
                                   contained in labels, and list of
                                   sensitivity values
     """
+    # If `sensitivities` is a DataArray, numpy-style indexing, as implemented
+    # in the following loop (`sensitivities[indices]`), will be interpreted as orthogonal indexing,
+    # which is DataArray’s default behavior. This would produce inflated clusters.
+    if hasattr(sensitivities, "values"):
+        sensitivities = sensitivities.values
+
     sensitivity_dict = {}
     max_label = int(np.nanmax(labels))
     n = 0
@@ -515,9 +521,13 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
     desired_num_labels = config["NumberOfElements"] - config["nBufferClusters"]
     last_ROI_element = int(orig_sv["StateVector"].max() - config["nBufferClusters"])
 
+    # Used to track if something has changed since we set the threshold
+    labels_assigned_since_last_threshold = False
+
     # User-supplied ClusteringThreshold stays fixed; if not, the threshold is recalibrated in each iteration below.
-    manual_threshold = "ClusteringThreshold" in config.keys()
-    if manual_threshold:
+    auto_threshold = "ClusteringThreshold" not in config.keys()
+
+    if not auto_threshold:
         dofs_threshold = float(config["ClusteringThreshold"])
     else:
         # default is to use the avg dofs per element
@@ -631,7 +641,6 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
 
         # In fill-grid mode, accept every generated cluster regardless of DOFS;
         # A filter_threshold of -1 is below the minimum possible total sensitivity (0).
-        # The recalibrated dofs_threshold is left unchanged so it stays valid for later iterations
         filter_threshold = -1 if fill_grid else dofs_threshold
 
         # get the n_highes labels with sensitivities above the
@@ -664,6 +673,8 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
         # informational output
         if len(n_max_labels) > 0:
             print(f"assigning {len(n_max_labels)} labels with agg level: {agg_level}")
+            labels_assigned_since_last_threshold = True
+
         # assign the n_max_labels to the labels dataset
         # starting from the highest sensitivity label in the dataset
         label_start = int(labels.max()) + 1
@@ -680,13 +691,16 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
 
         # Recalibrate dofs_threshold for the next iteration based on the DOFS
         # and cluster slots that remain after this iteration's assignments.
-        if not manual_threshold:
+        if  auto_threshold and labels_assigned_since_last_threshold:
             clusters_left = desired_num_labels - int(labels.max())
             if clusters_left > 0:
                 remaining_dofs = float(
                     sensi["Sensitivities"].where(labels == 0).sum()
                 )
+
                 dofs_threshold = remaining_dofs / clusters_left
+                print(f"Updated target DOFS per cluster (ClusteringThreshold): {dofs_threshold}")
+
                 if dofs_threshold > 1:
                     msg = (
                         f"Estimated dofs per element too high ({dofs_threshold}), "
@@ -694,6 +708,8 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
                     )
                     print(msg)
                     dofs_threshold = 1
+
+                labels_assigned_since_last_threshold = False
 
     # scale buffer elements to correct label range
     cluster_number_diff = last_ROI_element - int(labels.max())

--- a/src/components/statevector_component/aggregation.py
+++ b/src/components/statevector_component/aggregation.py
@@ -515,8 +515,9 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
     desired_num_labels = config["NumberOfElements"] - config["nBufferClusters"]
     last_ROI_element = int(orig_sv["StateVector"].max() - config["nBufferClusters"])
 
-    # set dofs threshold based on user preferences
-    if "ClusteringThreshold" in config.keys():
+    # User-supplied ClusteringThreshold stays fixed; if not, the threshold is recalibrated in each iteration below.
+    manual_threshold = "ClusteringThreshold" in config.keys()
+    if manual_threshold:
         dofs_threshold = float(config["ClusteringThreshold"])
     else:
         # default is to use the avg dofs per element
@@ -532,6 +533,7 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
 
     print(f"Target DOFS per cluster (ClusteringThreshold): {dofs_threshold}")
 
+    # max cluster size based on user preferences
     max_cluster_size = get_max_cluster_size(config, flat_sensi, desired_num_labels)
 
     try:
@@ -627,15 +629,15 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
                 cluster_by_country,
             )
 
-        # assign all remaining clusters if filling the grid
-        # by assigning dofs_threshold to artificially low value
-        if fill_grid:
-            dofs_threshold = -1
+        # In fill-grid mode, accept every generated cluster regardless of DOFS;
+        # A filter_threshold of -1 is below the minimum possible total sensitivity (0).
+        # The recalibrated dofs_threshold is left unchanged so it stays valid for later iterations
+        filter_threshold = -1 if fill_grid else dofs_threshold
 
         # get the n_highes labels with sensitivities above the
-        # dofs threshold and how many elements these labels contain
+        # threshold and how many elements these labels contain
         n_max_labels, n_highest, num_elements, _ = get_highest_labels_threshold(
-            out_labels, sensi["Sensitivities"], dofs_threshold
+            out_labels, sensi["Sensitivities"], filter_threshold
         )
 
         # if too many labels to assign, then we need to assign
@@ -675,6 +677,23 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
                 ind_max = np.where(labels.values == 0)
             labels.values[ind_max] = label_start
             label_start += 1
+
+        # Recalibrate dofs_threshold for the next iteration based on the DOFS
+        # and cluster slots that remain after this iteration's assignments.
+        if not manual_threshold:
+            clusters_left = desired_num_labels - int(labels.max())
+            if clusters_left > 0:
+                remaining_dofs = float(
+                    sensi["Sensitivities"].where(labels == 0).sum()
+                )
+                dofs_threshold = remaining_dofs / clusters_left
+                if dofs_threshold > 1:
+                    msg = (
+                        f"Estimated dofs per element too high ({dofs_threshold}), "
+                        "resetting ClusteringThreshold to 1"
+                    )
+                    print(msg)
+                    dofs_threshold = 1
 
     # scale buffer elements to correct label range
     cluster_number_diff = last_ROI_element - int(labels.max())


### PR DESCRIPTION
### Name and Institution

Name: Ioannis Binietoglou
Institution: Terra Arc

### Describe the update

Two bug fixes in the clustering algorithm, which could lead to sub optimal clusters:
1) An indexing bug that led to incorrectly estimating the per-cluster DoFs. 
2) Forcing native-resolution cells distorts the `ClusteringThreshold` and produces uneven clusters. The update recalculates the threshold in every iteration to produce more uniform cluster sizes.

### Issue addressed

#### 1. Wrong indexing when `sensitivities` is an `xarray.DataArray`

`get_highest_labels_threshold` indexes the `sensitivities` argument with `sensitivities[indices]` 
inside its per-label loop.  When `sensitivities` is an `xarray.DataArray`, this expression is interpreted as DataArray's 
default **orthogonal indexing**, not the numpy-style positional indexing the surrounding code assumes. 
The result is a 2-D selection rather than the intended flat selection, which inflates the 
per-label sensitivity sums and produces incorrect clusters.

Fix: if the input has a `.values` attribute, unwrap it to a plain numpy array before the loop, 
so subsequent indexing behaves as numpy positional indexing.

#### 2. Static initial threshold becomes unrepresentative after the first iteration

When `ClusteringThreshold` is not provided in the config, `update_sv_clusters` sets

```
dofs_threshold = sum(flat_sensi) / desired_num_labels
```

once at the start and reuses it for every clustering iteration. 

However, when a large portion of the domain is occupied by forced native-resolution pixels, 
the leftover budget is unrepresentative of the target DOFS-per-cluster for the remaining slots.

For example, let assume we have 12 cells, each with a sensitivity of 0.1; our target is to create 7 clusters,
keeping two of the cells at native resolution. The current algorithm will roughly do the following:
1) The sensitivities of the two native-resolution cells are assigned to 1.1 by `force_native_res_pixels`.
2) `dofs_threshold` is estimated as `(10*0.1 + 2*1.1) / 7 = 3.2 / 7 ≈ 0.46`.
3) With this threshold, the 10 non-native cells end up grouped as one large cluster and several single-cell clusters to fill the grid up to the target cluster number. 

Fix: Recompute `dofs_threshold` at the end of each iteration as:

```
dofs_threshold = remaining_dofs / remaining_cluster_slots
```

where `remaining_dofs` is the sum of sensitivity still attached to unassigned pixels (`labels == 0`) 
and `remaining_cluster_slots = desired_num_labels - max(labels)`.

In the example above, after the fix, the threshold is recomputed once the two native cells are assigned: `remaining_dofs / remaining_cluster_slots = 1.0 / 5 = 0.2`, avoiding oversized clusters.
