### PR TITLE
Log continuation of same config reruns 

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -5,6 +5,7 @@
 #SBATCH --mem=2000
 #SBATCH --mail-type=END
 #SBATCH -o "imi_output.log"
+#SBATCH --open-mode=append
 
 ## Uncomment to use PBS
 ###PBS -l nodes=1,ncpus=1
@@ -14,6 +15,36 @@
 # For documentation, see https://imi.readthedocs.io.
 #
 # Authors: Daniel Varon, Melissa Sulprizio, Lucas Estrada, Will Downs
+
+
+## Config log rotation - preserves history across re-launches with the same config
+if [[ $# == 1 ]]; then
+    _imi_cfg="$1"
+else
+    _imi_cfg="config.yml"
+fi
+_imi_tag=$(basename "$_imi_cfg" .yml)
+_imi_log="imi_output.log"
+_imi_sentinel="imi_output.log.tag"
+
+if [[ -s "$_imi_log" && -f "$_imi_sentinel" ]]; then
+    _imi_prev=$(<"$_imi_sentinel")
+    if [[ "$_imi_prev" != "$_imi_tag" ]]; then
+        _imi_ts=$(date +%Y%m%d_%H%M%S)
+        cp "$_imi_log" "imi_output.${_imi_prev}.${_imi_ts}.bak.log"
+        # Truncate instead of delete, because slurm has the file open
+        : > "$_imi_log"
+    fi
+fi
+# Always copy the current tag into the sentinel file
+echo "$_imi_tag" > "$_imi_sentinel"
+
+printf "\n================================================================================\n"
+printf "IMI invocation: %s  job=%s  config=%s\n" \
+    "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "${SLURM_JOB_ID:-no-slurm}" "$_imi_tag"
+printf "================================================================================\n"
+
+unset _imi_cfg _imi_tag _imi_log _imi_sentinel _imi_prev _imi_ts
 
 ##=======================================================================
 ## Import Shell functions


### PR DESCRIPTION
### Name and Institution (Required)

Name: Stefanos Chatzimichelakis
Institution: Terra Arc

### Describe the update

The log file `imi_output.log` in the run directory gets overwritten on each run start. This is problematic when a run has to be restarted for any reason (usually due to a spot instance shutdown).

This PR changes the write mode to append, in order to preserve the previous log entries after a restart.

To prevent creating a singular, unseperatable log across runs with the same config and with different configs, the following logic is implemented when starting a run:

- Always write the config filename in a sidecar file.
- If the log and sidecar files exist AND the sidecar indicates that the new run has the same config as the one that generated the log file, append to the file, but write a very recognizeable (and searchable) separator with the config filename and a timestamp to mark this invocation.
- If the log file and sidecar file exist but the sidecar indicates that the new run has a different config, archive the log file (appending the log file's config filename and a timestamp) and start a new log file.

The deciding factor is the config filename and not its contents, because the contents may change between runs (to turn off already completed setups, to adjust resource allocation etc.)