### PR TITLE
Kalman period autoadvance

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -93,6 +93,7 @@ UpdateFreqDays: 7
 NudgeFactor: 0.1
 MakePeriodsCSV: true
 CustomPeriodsCSV: "/path/to/periods.csv"
+AutoAdvanceFirstPeriod: false
 
 ## State vector
 CreateAutomaticRectilinearStateVectorFile: true

--- a/docs/source/user-guide/config-file.rst
+++ b/docs/source/user-guide/config-file.rst
@@ -164,8 +164,10 @@ Kalman filter options
      - Path to custom ``periods.csv`` with user-defined start and end dates for each Kalman filter update period.
    * - ``FirstPeriod``
      - Optional variable to specify which Kalman period to start on, if restarting an inversion. Default is ``1``.
+   * - ``AutoAdvanceFirstPeriod``
+     - When ``true``, at the end of every successfully completed Kalman period ``FirstPeriod`` is advanced in the active config file, so that a subsequent re-launch skips already-finished periods. Default is ``false``.
 
-State vector 
+State vector
 ~~~~~~~~~~~~
 .. list-table::
    :widths: 30, 70

--- a/src/components/kalman_component/kalman.sh
+++ b/src/components/kalman_component/kalman.sh
@@ -228,16 +228,24 @@ run_period() {
 
     # Persist period progress by advancing FirstPeriod in the active config, so a
     # subsequent re-launch of run_imi.sh skips already-completed periods.
-    
- if [[ "${AutoAdvanceFirstPeriod:-false}" == "true" ]]; then
-    next_period=$((period_i + 1))
-    if grep -q "^FirstPeriod:" "$ConfigPath"; then
-        sed -i "s/^FirstPeriod:.*/FirstPeriod: ${next_period}/" "$ConfigPath"
-    else
-        printf "\nFirstPeriod: %s\n" "${next_period}" >> "$ConfigPath"
+
+    if [[ "${AutoAdvanceFirstPeriod:-false}" == "true" ]]; then
+        # Check for marker files that indicate completion to ensure no advancing
+        # on an incomplete run.
+        sf_marker="${RunDirs}/archive_sf/posterior_sf_period${period_i}.nc"
+        restart_marker="${PosteriorRunDir}/Restarts/GEOSChem.Restart.${EndDate_i}_0000z.nc4"
+        if [[ -f "$sf_marker" && -e "$restart_marker" ]]; then
+            next_period=$((period_i + 1))
+            if grep -q "^FirstPeriod:" "$ConfigPath"; then
+                sed -i "s/^FirstPeriod:.*/FirstPeriod: ${next_period}/" "$ConfigPath"
+            else
+                printf "\nFirstPeriod: %s\n" "${next_period}" >> "$ConfigPath"
+            fi
+            echo "Period ${period_i} complete; advanced FirstPeriod to ${next_period} in ${ConfigPath}"
+        else
+            echo "WARNING: period ${period_i} finished but did not produce expected files; FirstPeriod *not* advanced"
+        fi
     fi
-    echo "Period ${period_i} complete; advanced FirstPeriod to ${next_period} in ${ConfigPath}"
-fi
 
     # Move to next time step
     print_stats

--- a/src/components/kalman_component/kalman.sh
+++ b/src/components/kalman_component/kalman.sh
@@ -226,6 +226,19 @@ run_period() {
     # Delete unneeded daily restart files from Jacobian and posterior directories
     python ${InversionPath}/src/components/kalman_component/cull_restarts.py $JacobianRunsDir $PosteriorRunDir $StartDate_i $EndDate_i
 
+    # Persist period progress by advancing FirstPeriod in the active config, so a
+    # subsequent re-launch of run_imi.sh skips already-completed periods.
+    
+ if [[ "${AutoAdvanceFirstPeriod:-false}" == "true" ]]; then
+    next_period=$((period_i + 1))
+    if grep -q "^FirstPeriod:" "$ConfigPath"; then
+        sed -i "s/^FirstPeriod:.*/FirstPeriod: ${next_period}/" "$ConfigPath"
+    else
+        printf "\nFirstPeriod: %s\n" "${next_period}" >> "$ConfigPath"
+    fi
+    echo "Period ${period_i} complete; advanced FirstPeriod to ${next_period} in ${ConfigPath}"
+fi
+
     # Move to next time step
     print_stats
     echo -e "Moving to next iteration\n"

--- a/src/utilities/sanitize_input_yaml.py
+++ b/src/utilities/sanitize_input_yaml.py
@@ -114,6 +114,8 @@ optional_rules: Dict[str, Rule] = {
     "NudgeFactor": float,
     "DynamicKFClustering": bool,
     "CustomPeriodsCSV": str,
+    "FirstPeriod": int,
+    "AutoAdvanceFirstPeriod": bool,
     # ReducedDimensionStateVector-related
     "ClusteringMethod": str,
     "NumberOfElements": int,


### PR DESCRIPTION
### Name and Institution (Required)

Name: Stefanos Chatzimichelakis
Institution: Terra Arc

### Describe the update

When an interruption occurs during a non-Kalman run, restarting with setup disabled is enough to mostly skip over already completed costly jacobian runs and continue without much overhead and without redoing too much work.

A Kalman run that is interrupted after the first period is completed, however, will restart from the first period, causing very large  amounts of overhead (depending on the number of periods already completed), rerunning already completed jacobians, rerunning (and changing) posteriors and more, making any kind of recovery impossible.

The only way to correctly continue the interrupted run is to use the `FirstPeriod` config variable, but that requires constant supervision and intervention, and would be unfeasible for runs with large numbers of periods.

This PR adds an `AutoAdvanceFirstPeriod` boolean config variable (optional, default `False`) that will autoincrement the `FirstPeriod` config variable in the run config file after each period is successfully completed.

The increment logic is simple - if `kalman.sh`s `run_period()` reaches the end, and the expected files are present in the period folder, the period completed successfully, and it is therefore safe to advance `FirstPeriod`.

This would enable feasible restart automation for Kalman runs, to mitigate spot instance stoppages.
