### PR TITLE
Allow lower number of elements than `NumberOfElements` if the remaining native elements are not enough

### DIFF
--- a/src/components/kalman_component/kalman.sh
+++ b/src/components/kalman_component/kalman.sh
@@ -144,6 +144,24 @@ run_period() {
     ##  Submit all Jacobian simulations OR submit only the Prior simulation
     ##=======================================================================
 
+    # Refresh nElements in this period's run_inversion.sh based on the
+    # actual number of elements - can be less than NumberOfElements
+    # if native cells run out before all requested cluster slots are filled.
+
+    nElements_p=$(ncmax StateVector ${RunDirs}/StateVector.nc)
+    if "$OptimizeBCs"; then
+        nElements_p=$((nElements_p + 4)) # OptimizeBC adds 4 elements
+    fi
+    if "$OptimizeOH"; then # OptimizeOH adds 1 element if regional and 2 if global
+        if "$isRegional"; then
+            nElements_p=$((nElements_p + 1)) 
+        else
+            nElements_p=$((nElements_p + 2))
+        fi
+    fi
+    sed -i -E "s|^nElements=.*|nElements=${nElements_p}|" "${RunDirs}/kf_inversions/period${period_i}/run_inversion.sh"
+    echo "Period ${period_i}: refreshed nElements to ${nElements_p} in run_inversion.sh"
+
     # run jacobian simulation for the given period
     run_jacobian
 

--- a/src/components/statevector_component/aggregation.py
+++ b/src/components/statevector_component/aggregation.py
@@ -606,11 +606,15 @@ def update_sv_clusters(config, flat_sensi, orig_sv):
             # if there are fewer clusters left to assign than n_labels
             # then evenly distribute the remaining clusters
             # prevents the algorithm from generating one massive cluster
-            agg_level = int(elements_left / clusters_left)
+            # Also limit clusters if they would exceed the number of remaining elements.
+            n_clusters_fill = min(clusters_left, elements_left)
+            if n_clusters_fill <= 0:
+                break
+            agg_level = max(1, int(elements_left / n_clusters_fill))
             print("Filling grid with remaining clusters.")
             out_labels = cluster_data_kmeans(
                 sensi["Sensitivities"].where(labels == 0),
-                clusters_left,
+                n_clusters_fill,
                 mini_batch,
                 cluster_by_country,
             )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Stefanos Chatzimichelakis
Institution: Terra Arc

### Describe the update

When clustering is enabled, the clustering algorithm may reach a point where the remaining native elements are not enough for the total element count to reach the `NumberOfElements` config value.
This may happen due to a very large value of `NumberOfElements`, multiple `ForcedNativeResolutionElements` that "consume" too many clusters early, and other edge cases.
With this fix, the final element number is allowed to be less than the set `NumberOfElements` without erroring out.

A related change in `kalman.sh` was necessary in order to propagate the (now potentially variable) final number of elements to the inversion run script. As far as I could tell, this was the only site that used the unchanged config var directly.