### PR TITLE
fix 2d array indexing

### DIFF
--- a/src/inversion_scripts/plumes.py
+++ b/src/inversion_scripts/plumes.py
@@ -274,9 +274,11 @@ class PointSources:
             ds_mean = self.grid_ds.where(criteria).mean("observer")
             # select valid cells
             valid = ~np.isnan(ds_mean['emission_rate'].values)
+            # extract indices of valid cells
+            lat_idx, lon_idx = np.where(valid)
             # extract corresponding lat/lon values
-            latvals = ds_mean["lat"].values[valid]
-            lonvals = ds_mean["lon"].values[valid]
+            latvals = ds_mean["lat"].values[lat_idx]
+            lonvals = ds_mean["lon"].values[lon_idx]
 
             # stack as [lon,lat] list
             coords = np.stack([lonvals, latvals], axis=1).tolist()


### PR DESCRIPTION
### Name and Institution (Required)

Name: Vedant Rautela
Institution: MIT

### Describe the update

This PR fixes a bug in the point source dataset section of the IMI. Specifically the get_gridded_coords method in plumes.py fails when there are actually point sources in the ROI.

<img width="851" height="374" alt="image" src="https://github.com/user-attachments/assets/602a2170-ba43-4eb5-96a9-8bb504effb00" />
