### PR TITLE
Make doing GEOS-Chem compilation configurable

### DIFF
--- a/run_imi.sh
+++ b/run_imi.sh
@@ -52,6 +52,7 @@ unset _imi_cfg _imi_tag _imi_log _imi_sentinel _imi_prev _imi_ts
 source src/utilities/common.sh
 source src/components/setup_component/setup.sh
 source src/components/template_component/template.sh
+source src/components/template_component/compile.sh
 source src/components/statevector_component/statevector.sh
 source src/components/hemco_prior_emis_component/hemco_prior_emis.sh
 source src/components/preview_component/preview.sh
@@ -219,7 +220,11 @@ python src/utilities/test_TROPOMI_dir.py $satelliteCache
 ##  Run the setup script
 ##=======================================================================
 if "$RunSetup"; then
+    echo 'calling setup_imi'
     setup_imi
+    echo 'setup_imi done'
+else
+    echo 'skipping setup_imi'
 fi
 setup_end=$(date +%s)
 
@@ -227,7 +232,11 @@ setup_end=$(date +%s)
 ##  Submit spinup simulation
 ##=======================================================================
 if "$DoSpinup"; then
+    echo 'calling run_spinup'
     run_spinup
+    echo 'run_spinup done'
+else
+    echo 'skipping run_spinup'
 fi
 
 if ("$DoOSSE" && "$EnableOSSE"); then
@@ -239,29 +248,47 @@ fi
 ##  Run Kalman Filter Mode
 ##=======================================================================
 if "$KalmanMode"; then
+    echo 'calling setup_kf'
     setup_kf
+    echo 'setup_kf done'
+    echo 'calling run_kf'
     run_kf
+    echo 'run_kf done'
+else
+    echo 'skipping run_kf'
 fi
 
 ##=======================================================================
 ##  Submit Jacobian simulation
 ##=======================================================================
 if ("$DoJacobian" && ! "$KalmanMode"); then
+    echo 'calling run_jacobian'
     run_jacobian
+    echo 'run_jacobian done'
+else
+    echo 'skipping run_jacobian'
 fi
 
 ##=======================================================================
 ##  Process data and run inversion
 ##=======================================================================
 if ("$DoInversion" && ! "$KalmanMode"); then
+    echo 'calling run_inversion'
     run_inversion
+    echo 'run_inversion done'
+else
+    echo 'skipping run_inversion'
 fi
 
 ##=======================================================================
 ##  Submit posterior simulation and process the output
 ##=======================================================================
 if ("$DoPosterior" && ! "$KalmanMode"); then
+    echo 'calling run_posterior'
     run_posterior
+    echo 'run_posterior done'
+else
+    echo 'skipping run_posterior'
 fi
 
 printf "\n=== DONE RUNNING THE IMI ===\n"
@@ -273,7 +300,11 @@ printf "\nIMI ended   : %s" "$end_time"
 printf "\n"
 
 if ! "$KalmanMode"; then
+    echo 'calling print_stats'
     print_stats
+    echo 'print_stats done'
+else
+    echo 'skipping print_stats'
 fi
 
 # Copy output log to run directory for storage
@@ -287,7 +318,11 @@ cp $ConfigFile "${RunDirs}/config_${RunName}.yml"
 
 # Upload output to S3 if specified
 if "$S3Upload"; then
+    echo 'calling s3_upload.py to upload output to S3'
     python src/utilities/s3_upload.py $ConfigFile
+    echo 's3 upload done'
+else
+    echo 'skipping s3 upload'
 fi
 
 exit 0

--- a/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
+++ b/src/components/hemco_prior_emis_component/hemco_prior_emis.sh
@@ -237,7 +237,7 @@ emis.to_netcdf(sys.argv[2])
 ' "$1" "$2"
 }
 
-# Description: Setup Spinup Directory
+# Description: Setup HEMCO prior directory for GCHP
 # Usage:
 #   setup_prior_gchp
 setup_prior_gchp() {
@@ -348,6 +348,7 @@ run_prior_gchp() {
         -t $RequestedTime \
         -p $SchedulerPartition \
         -W ${RunName}_HEMCO_Prior_Emis.run
+    printf "Waiting for job to complete..."
     wait
 
     # check if exited with non-zero exit code

--- a/src/components/setup_component/setup.sh
+++ b/src/components/setup_component/setup.sh
@@ -280,7 +280,16 @@ setup_imi() {
     fi
 
     ##=======================================================================
-    ## Generate Prior Emissions using a HEMCO standalone run or GCHP prior run
+    ## Compile GEOS-Chem
+    ##=======================================================================
+    if "$CompileGEOSChem"; then
+        compile_geoschem
+    fi
+
+
+    
+    ##=======================================================================
+    ## Setup and Generate Prior Emissions
     ##=======================================================================
     if "$DoHemcoPriorEmis"; then
         if [ "$UseGCHP" != "true" ]; then

--- a/src/components/template_component/compile.sh
+++ b/src/components/template_component/compile.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Functions available in this file include:
+#   - compile_geoschem
+
+# Description: Compile GEOS-Chem, either GC-Classic or GCHP 
+# Usage:
+#   compile_geoschem
+compile_geoschem() {
+
+    # Compile GEOS-Chem/GCHP and store in <src>/build/bin directory
+    if "$UseGCHP"; then
+	printf "\n=== COMPILING GCHP ===\n"
+        cd ${GCHPPath}/run
+        execname="gchp"
+        build_dir=${GCHPPath}/build
+        KPP_dir=${GCHPPath}/src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/KPP
+    else
+	printf "\n=== COMPILING GC-Classic ===\n"
+        cd ${GCClassicPath}/run
+        execname="gcclassic"
+        build_dir=${GCClassicPath}/build
+        KPP_dir=${GCClassicPath}/src/GEOS-Chem/KPP
+    fi
+
+    mkdir -p ${build_dir}
+    cd ${build_dir}
+    # first build a default exexutable without Jacobian tracers
+    if [ -f "bin/${execname}.default" ]; then
+        echo "Executable bin/${execname}.default already exists — skipping rebuild."
+    else
+        echo "Building ${execname}.default ..."
+
+        # remove CMakeCache.txt once to initialize JACOBIAN cmake option
+        rm -f CMakeCache.txt
+        cd "${KPP_dir}/carbon"
+        if [ ! -f carbon.eqn.default ]; then
+            mv carbon.eqn carbon.eqn.default
+        fi
+        ln -nsf carbon.eqn.default carbon.eqn
+        # initialize KPP mechanism to be the default carbon equations
+        cd ${KPP_dir}
+        ./build_mechanism.sh carbon >> "${build_dir}/build_geoschem.log" 2>&1 \
+            || { echo "ERROR: build_mechanism.sh carbon failed." >&2; exit 1; }
+
+        cd "${build_dir}"
+        cmake .. >> build_geoschem.log 2>&1
+        cmake . -DMECH=carbon -DJACOBIAN=n >> build_geoschem.log 2>&1
+        make -j >> build_geoschem.log 2>&1
+
+        mv "bin/${execname}" "bin/${execname}.default"
+    fi
+
+    # then expand a series of carbon equations for Jacobian tracers
+    # sanity check on NumJacobianTracers
+    if ! [[ "$NumJacobianTracers" =~ ^[0-9]+$ ]] || [ "$NumJacobianTracers" -eq 0 ]; then
+        echo "ERROR: NumJacobianTracers must be a positive integer > 0." >&2
+        exit 1
+    fi
+    # determine number of executables to be built based on NumJacobianTracers
+    # get the ceiling number rounded to 10s
+    upper=$(( (NumJacobianTracers + 9) / 10 * 10 ))
+
+    cd "${build_dir}"
+    cmake . -DMECH=carbon -DJACOBIAN=y >> build_geoschem.log 2>&1
+    for n in $(seq 10 10 $upper); do
+        if [ -f "bin/${execname}.${n}" ]; then
+            echo "Executable bin/${execname}.${n} already exists — skipping rebuild."
+        else
+            echo "Building ${execname}.${n} ..."
+
+            cd ${KPP_dir}/carbon
+            ${InversionPath}/src/utilities/expand_carbon_eqn.py \
+                carbon.eqn.default ${n} > carbon.eqn.${n}
+            ln -nsf carbon.eqn.${n} carbon.eqn
+            # generate KPP carbon mechanism
+            cd ${KPP_dir}
+            ./build_mechanism.sh carbon >> "${build_dir}/build_geoschem.log" 2>&1 \
+                || { echo "ERROR: build_mechanism.sh carbon failed." >&2; exit 1; }
+            # build GCC/GCHP with expanded carbon mechanism for Jacobian tracers
+            cd ${build_dir}
+            make -j >>build_geoschem.log 2>&1
+            mv bin/${execname} bin/${execname}.${n}
+        fi
+    done
+
+    printf "\nDone compiling GEOS-Chem \n\nSee ${build_dir}/build_geoschem.log for details\n\n"
+
+    # Navigate back to working directory
+    cd ${RunDirs}
+
+    printf "\n=== DONE BUILDING GEOS-Chem ===\n"
+}

--- a/src/components/template_component/template.sh
+++ b/src/components/template_component/template.sh
@@ -116,6 +116,7 @@ setup_template() {
         RunDuration=$(get_run_duration "$StartDate" "$EndDate")
         sed -i -e "s/^BEG_DATE:.*/BEG_DATE:     ${StartDate} 000000/" \
             -e "s/^END_DATE:.*/END_DATE:     ${EndDate} 000000/" CAP.rc
+
         echo "$StartDate 000000" > cap_restart
         sed -i -e "s/Run_Duration=\"[0-9]\{8\} 000000\"/Run_Duration=\"${RunDuration} 000000\"/" \
             -e "s/^CS_RES=.*/CS_RES=${CS_RES}/" \
@@ -124,11 +125,14 @@ setup_template() {
             -e "s/^NUM_CORES_PER_NODE=.*/NUM_CORES_PER_NODE=${NUM_CORES_PER_NODE}/" \
             -e 's/^AutoUpdate_Diagnostics=.*$/AutoUpdate_Diagnostics=OFF/' \
             setCommonRunSettings.sh
-        # turn on monthly checkpoint
+
+	# turn on monthly checkpoint
         sed -i -e 's/^Midrun_Checkpoint=OFF/Midrun_Checkpoint=ON/' \
             -e 's/^Checkpoint_Freq=.*/Checkpoint_Freq=monthly/' \
             setCommonRunSettings.sh
         sed -i -e "s/monthly:[[:space:]]*1/monthly:        0/g" HISTORY.rc
+
+	# Set stretched grid paramaters from IMI config
         if "$STRETCH_GRID"; then
             sed -i -e "s/^STRETCH_GRID=.*/STRETCH_GRID=ON/" \
                 -e "s/^STRETCH_FACTOR=.*/STRETCH_FACTOR=${STRETCH_FACTOR}/" \
@@ -263,48 +267,8 @@ setup_template() {
         cp ${InversionPath}/src/geoschem_run_scripts/run.template .
     fi
 
-    # Compile GEOS-Chem and store executable in GEOSChem_build directory
-    if [[ -f "../GEOSChem_build/gchp" || -f "../GEOSChem_build/gcclassic" ]]; then
-        printf "\nGEOS-Chem executable is already built and stored in GEOSChem_build\n"
-        rm -rf build
-    else
-        cd build
-        if "$UseGCHP"; then
-            printf "\nCompiling GCHP...\n"
-            cmake ${InversionPath}/GCHP >>build_geoschem.log 2>&1
-        else
-            printf "\nCompiling GEOS-Chem...\n"
-            cmake ${InversionPath}/GCClassic >>build_geoschem.log 2>&1
-        fi
-        cmake . -DRUNDIR=.. -DMECH=carbon >>build_geoschem.log 2>&1
-        make -j install >>build_geoschem.log 2>&1
-        cd ..
-        if "$UseGCHP"; then
-            if [[ -f gchp ]]; then
-                mkdir ../GEOSChem_build
-                mv -v gchp ../GEOSChem_build/
-                mv build/CMakeCache.txt ../GEOSChem_build
-                mv build/build_geoschem.log ../GEOSChem_build
-                rm -rf build
-            else
-                printf "\nGCHP build failed! \n\nSee ${RunDirs}/GEOSChem_build/build_geoschem.log for details\n"
-                exit 999
-            fi
-        else
-            if [[ -f gcclassic ]]; then
-                mv build_info ../GEOSChem_build
-                mv -v gcclassic ../GEOSChem_build/
-                mv build/build_geoschem.log ../GEOSChem_build
-                rm -rf build
-            else
-                printf "\nGEOS-Chem build failed! \n\nSee ${RunDirs}/GEOSChem_build/build_geoschem.log for details\n"
-                exit 999
-            fi
-        fi
-        printf "\nDone compiling GEOS-Chem \n\nSee ${RunDirs}/GEOSChem_build for details\n\n"
-    fi
-    # Navigate back to top-level directory
-    cd ..
+    # Navigate back to working directory
+    cd ${RunDirs}
 
     printf "\n=== DONE CREATING TEMPLATE RUN DIRECTORY ===\n"
 }


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update changes the IMI shell scripts such compiling GEOS-Chem may be toggled on or off. It also adds status updates in the main run script to be more clear about what shell scripts are run, when they are done, and which are skipped.

In my GCHP IMI run directory, I changed the configuration to this. However, I did not update any of the environment files in IMI repository for this PR.

```
##--------------                                                                                                                                   
## Setup modules                                                                                                                                   
##   Turn on/off different steps in setting up the inversion                                                                                       
RunSetup: true

# The following settings apply only if RunSetup is set to true                                                                                     
SetupTemplateRundir: true
CompileGEOSChem: false
DoHemcoPriorEmis: true

# Do these after the above has already run                                                                                                         
SetupSpinupRun: false
SetupJacobianRuns: false
SetupInversion: false
SetupPosteriorRun: false

#----------------                                                                                                                                  
## Run modules                                                                                                                                     
##   Turn on/off different steps in performing the inversion                                                                                                                                                                                                               
DoSpinup: false
DoJacobian: false
ReDoJacobian: false
DoInversion: false
DoPosterior: false
```

I have only used this for GCHP IMI, and at the time it was based off of an older version. I rebased off of dev for this PR but have not further tested. The code should work for GC-Classic but it has not been tested in any version yet.

Also note, there is a section in new file `compile.sh` for building executables for varying number of Jacobian tracers.  This was written originally for `template.sh` by Dandan Zhang (@1Dandan). If bringing this PR into the IMI before the rest of the GCHP IMI updates which enable using Jacobian tracers in KPP, then that section may be commented out.