### PR TITLE
Fix `UseWaterObs` always evaluating to True in `jacobian.py`

### DIFF
--- a/src/components/posterior_component/posterior.sh
+++ b/src/components/posterior_component/posterior.sh
@@ -296,7 +296,7 @@ run_posterior() {
     kf_period=1
 
     printf "\n=== Calling jacobian.py to sample posterior simulation (without jacobian sensitivity analysis) ===\n"
-    python ${InversionPath}/src/inversion_scripts/jacobian.py ${InvDir} ${ConfigPath} $StartDate_i $EndDate_i $LonMinInvDomain $LonMaxInvDomain $LatMinInvDomain $LatMaxInvDomain $nElements $Species $satelliteCache $SatelliteProduct $UseWaterObs $isPost $kf_period $buildJacobian False
+    python ${InversionPath}/src/inversion_scripts/jacobian.py ${InvDir} ${ConfigPath} $StartDate_i $EndDate_i $LonMinInvDomain $LonMaxInvDomain $LatMinInvDomain $LatMaxInvDomain $nElements $satelliteCache $isPost $kf_period $buildJacobian False
     wait
     printf "\n=== DONE sampling the posterior simulation ===\n\n"
     posterior_end=$(date +%s)

--- a/src/inversion_scripts/jacobian.py
+++ b/src/inversion_scripts/jacobian.py
@@ -83,29 +83,25 @@ if __name__ == "__main__":
     species = sys.argv[10]
     satellite_cache = sys.argv[11]
     satellite_product = sys.argv[12]
-    use_water_obs = sys.argv[13]
-    isPost = sys.argv[14]
+    use_water_obs = sys.argv[13].strip().lower() == "true"
+    isPost = sys.argv[14].strip().lower() == "true"
     period_i = int(sys.argv[15])
-    build_jacobian = sys.argv[16]
-    viz_prior = sys.argv[17]
+    build_jacobian = sys.argv[16].strip().lower() == "true"
+    viz_prior = sys.argv[17].strip().lower() == "true"
 
     # Reformat start and end days for datetime in configuration
     start = f"{startday[0:4]}-{startday[4:6]}-{startday[6:8]} 00:00:00"
     end = f"{endday[0:4]}-{endday[4:6]}-{endday[6:8]} 23:59:59"
 
     # Configuration
-    if build_jacobian.lower() == "true":
-        build_jacobian = True
-    else:
-        build_jacobian = False
-    if isPost.lower() == "false":  # if sampling prior simulation
+    if isPost:  # if sampling prior simulation
         gc_cache = f"{workdir}/data_geoschem"
         outputdir = f"{workdir}/data_converted"
         vizdir = f"{workdir}/data_visualization"
 
         # for lognormal, we also sample the prior simulation in a
         # separate call to jacobian.py solely for visualization purposes
-        if viz_prior.lower() == "true":
+        if viz_prior:
             gc_cache = f"{gc_cache}_prior"
             outputdir = f"{outputdir}_prior"
             vizdir = f"{vizdir}_prior"

--- a/src/inversion_scripts/jacobian.py
+++ b/src/inversion_scripts/jacobian.py
@@ -80,19 +80,21 @@ if __name__ == "__main__":
     latmin = float(sys.argv[7])
     latmax = float(sys.argv[8])
     n_elements = int(sys.argv[9])
-    species = sys.argv[10]
-    satellite_cache = sys.argv[11]
-    satellite_product = sys.argv[12]
-    use_water_obs = sys.argv[13].strip().lower() == "true"
-    isPost = sys.argv[14].strip().lower() == "true"
-    period_i = int(sys.argv[15])
-    build_jacobian = sys.argv[16].strip().lower() == "true"
-    viz_prior = sys.argv[17].strip().lower() == "true"
+    satellite_cache = sys.argv[10]
+    isPost = sys.argv[11].strip().lower() == "true"
+    period_i = int(sys.argv[12])
+    build_jacobian = sys.argv[13].strip().lower() == "true"
+    viz_prior = sys.argv[14].strip().lower() == "true"
 
     # Reformat start and end days for datetime in configuration
     start = f"{startday[0:4]}-{startday[4:6]}-{startday[6:8]} 00:00:00"
     end = f"{endday[0:4]}-{endday[4:6]}-{endday[6:8]} 23:59:59"
 
+    # Get config parameters
+    satellite_product = config["SatelliteProduct"]
+    use_water_obs = config["UseWaterObs"]
+    species = config["Species"]
+        
     # Configuration
     if not isPost:  # if sampling prior simulation
         gc_cache = f"{workdir}/data_geoschem"

--- a/src/inversion_scripts/jacobian.py
+++ b/src/inversion_scripts/jacobian.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     end = f"{endday[0:4]}-{endday[4:6]}-{endday[6:8]} 23:59:59"
 
     # Configuration
-    if isPost:  # if sampling prior simulation
+    if not isPost:  # if sampling prior simulation
         gc_cache = f"{workdir}/data_geoschem"
         outputdir = f"{workdir}/data_converted"
         vizdir = f"{workdir}/data_visualization"

--- a/src/inversion_scripts/run_inversion.sh
+++ b/src/inversion_scripts/run_inversion.sh
@@ -145,11 +145,11 @@ else
     jacobian_sf=${InvDir}/jacobian_scale_factors.npy
 fi
 
-python -u ${InvDir}/jacobian.py ${InvDir} ${invPath}/${configFile} $StartDate $EndDate $LonMinInvDomain $LonMaxInvDomain $LatMinInvDomain $LatMaxInvDomain $nElements $Species $satelliteCache $SatelliteProduct $UseWaterObs $isPost $period_i $buildJacobian False; wait
+python -u ${InvDir}/jacobian.py ${InvDir} ${invPath}/${configFile} $StartDate $EndDate $LonMinInvDomain $LonMaxInvDomain $LatMinInvDomain $LatMaxInvDomain $nElements $satelliteCache $isPost $period_i $buildJacobian False; wait
 if "$LognormalErrors"; then
     # for lognormal error visualization of the prior we sample the prior run
     # without constructing the jacobian matrix
-    python ${InvDir}/jacobian.py ${InvDir} ${invPath}/${configFile} $StartDate $EndDate $LonMinInvDomain $LonMaxInvDomain $LatMinInvDomain $LatMaxInvDomain $nElements $Species $satelliteCache $SatelliteProduct $UseWaterObs $isPost $period_i False True; wait
+    python ${InvDir}/jacobian.py ${InvDir} ${invPath}/${configFile} $StartDate $EndDate $LonMinInvDomain $LonMaxInvDomain $LatMinInvDomain $LatMaxInvDomain $nElements $satelliteCache $isPost $period_i False True; wait
 fi
 printf " DONE -- jacobian.py\n\n"
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update
Fix `UseWaterObs` always evaluating to True in `jacobian.py` and use the same pattern for other boolean cli args.

### Problem

`jacobian.py` receives several booleans as positional command-line arguments from the driver shell scripts (`run_inversion.sh`, `posterior.sh`), which pass them as the literal strings `"True"` / `"False"`. In `jacobian.py` these were stored as raw strings and then passed straight through into `params["use_water_obs"]`, which eventually reaches `filter_tropomi` / `filter_blended` in `src/inversion_scripts/utils.py` as a plain `if use_water_obs:` check.

Because a non-empty string is always truthy in Python, `use_water_obs` was effectively`True` for every run, regardless of the `UseWaterObs` setting in the config file. Water observations were therefore retained in the observation filter even when the user had explicitly disabled them.

I also adjusted the other booleans `build_jacobian`, `isPost`, and `viz_prior` to use the same pattern to avoid future confusion.
```python
use_water_obs = sys.argv[13].strip().lower() == "true"
isPost        = sys.argv[14].strip().lower() == "true"
build_jacobian = sys.argv[16].strip().lower() == "true"
viz_prior     = sys.argv[17].strip().lower() == "true"
```