### PR TITLE
Allow BufferRings = 0 in regional inversions

### DIFF
--- a/src/inversion_scripts/jacobian.py
+++ b/src/inversion_scripts/jacobian.py
@@ -83,29 +83,25 @@ if __name__ == "__main__":
     species = sys.argv[10]
     satellite_cache = sys.argv[11]
     satellite_product = sys.argv[12]
-    use_water_obs = sys.argv[13]
-    isPost = sys.argv[14]
+    use_water_obs = sys.argv[13].strip().lower() == "true"
+    isPost = sys.argv[14].strip().lower() == "true"
     period_i = int(sys.argv[15])
-    build_jacobian = sys.argv[16]
-    viz_prior = sys.argv[17]
+    build_jacobian = sys.argv[16].strip().lower() == "true"
+    viz_prior = sys.argv[17].strip().lower() == "true"
 
     # Reformat start and end days for datetime in configuration
     start = f"{startday[0:4]}-{startday[4:6]}-{startday[6:8]} 00:00:00"
     end = f"{endday[0:4]}-{endday[4:6]}-{endday[6:8]} 23:59:59"
 
     # Configuration
-    if build_jacobian.lower() == "true":
-        build_jacobian = True
-    else:
-        build_jacobian = False
-    if isPost.lower() == "false":  # if sampling prior simulation
+    if isPost:  # if sampling prior simulation
         gc_cache = f"{workdir}/data_geoschem"
         outputdir = f"{workdir}/data_converted"
         vizdir = f"{workdir}/data_visualization"
 
         # for lognormal, we also sample the prior simulation in a
         # separate call to jacobian.py solely for visualization purposes
-        if viz_prior.lower() == "true":
+        if viz_prior:
             gc_cache = f"{gc_cache}_prior"
             outputdir = f"{outputdir}_prior"
             vizdir = f"{vizdir}_prior"

--- a/src/inversion_scripts/jacobian.py
+++ b/src/inversion_scripts/jacobian.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     end = f"{endday[0:4]}-{endday[4:6]}-{endday[6:8]} 23:59:59"
 
     # Configuration
-    if isPost:  # if sampling prior simulation
+    if not isPost:  # if sampling prior simulation
         gc_cache = f"{workdir}/data_geoschem"
         outputdir = f"{workdir}/data_converted"
         vizdir = f"{workdir}/data_visualization"

--- a/src/utilities/make_state_vector_file.py
+++ b/src/utilities/make_state_vector_file.py
@@ -47,14 +47,15 @@ def check_grid_compatibility(lat_min, lat_max, lon_min, lon_max, land_cover_pth)
     return compatible
 
 
-def cluster_buffer_elements(data, offset):
+def cluster_buffer_elements(data, offset, buffer_reduction_factor):
     """
     Description:
         Cluster all 0 valued elements in dataarray into desired num clusters
     arguments:
-        data       [][]dataarray : xarrray sensitivity data
-        offset              bool : offset labels by this integer value
-    Returns:       [][]dataarray : labeled data
+        data            [][]dataarray : xarrray sensitivity data
+        offset                   bool : offset labels by this integer value
+        buffer_reduction_factor float : factor to reduce the number of buffer elements
+    Returns:            [][]dataarray : labeled data
     """
 
     # Get the latitude and longitude coordinates as separate arrays
@@ -69,8 +70,13 @@ def cluster_buffer_elements(data, offset):
     # labels = np.zeros(Z.shape)
     valid_indices = np.where(Z == 0)[0]
 
-    # Get the number of clusters
-    num_clusters = int(np.floor( len(valid_indices) / 4 ))
+    # Nothing to cluster (eg. BufferRings = 0), so return the data unchanged
+    if len(valid_indices) == 0:
+        return data_copy
+
+    # Get the number of clusters, using at least one cluster for any
+    # remaining buffer elements
+    num_clusters = max(1, int(np.floor( len(valid_indices) / buffer_reduction_factor )))
 
     # Flatten the latitude and longitude arrays into a 2D grid
     # only keeping valid indices
@@ -136,6 +142,7 @@ def make_state_vector_file(
     lon_max = config["LonMax"]
     is_regional = config["isRegional"]
     buffer_rings = config["BufferRings"]
+    buffer_reduction_factor = config["BufferReductionFactor"]
     emis_threshold = config["EmisThreshold"]
     buffer_min_lat = 0
     buffer_min_lon = 0
@@ -286,9 +293,17 @@ def make_state_vector_file(
     # Assign buffer pixels (the remaining 0's) to state vector
     # -------------------------------------------------------------------------
     if is_regional:
-        statevector = cluster_buffer_elements(
-            statevector, statevector.max().item()
-        )
+        if (statevector.values == 0).any():
+            statevector = cluster_buffer_elements(
+                statevector, statevector.max().item(), buffer_reduction_factor
+            )
+        else:
+            # BufferRings = 0, so the entire buffer area is taken up by the
+            # 4 non advected cells on each side, which are excluded (-9999)
+            print(
+                "No buffer elements to cluster; the state vector contains "
+                "only elements in the region of interest."
+            )
 
     refyear = 2000
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lucas Estrada
Institution: Harvard ACMG

### Describe the update

Setting `BufferRings: 0` for a regional inversion crashed state vector generation. With 0 rings, the buffer band zeroed out in`make_state_vector_file` is entirely overwritten by the `-9999` trim of the 4 non-advected cells on each side, leaving no `0`-valued cells to cluster. `cluster_buffer_elements` then called `KMeans(n_clusters=0)`, which raises an error.

To fix this:
- `cluster_buffer_elements` returns the data unchanged when there are no buffer elements, and uses at least 1 cluster so a small number of leftover cells can't produce `n_clusters=0`.
- Only invoke the clustering step when buffer elements actually exist; print an explanatory message otherwise.
- Use the existing `BufferReductionFactor` config option instead of the hardcoded divisor of `4` when computing the number of buffer clusters. @hannahnesser I think that this is the intended behavior, but please confirm.