### PR TITLE
Use mean emissions in y-F(x') term for lognormal inversion

### DIFF
--- a/src/inversion_scripts/lognormal_invert.py
+++ b/src/inversion_scripts/lognormal_invert.py
@@ -155,7 +155,6 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
         # the lognormal part of K gets scaled by prior_scale to convert to median
         K_ROI = K_temp[:, :-num_normal_elems]
         K_normal = K_temp[:, -num_normal_elems:]
-        K_ROI = prior_scale * K_ROI
         K_full = np.concatenate((K_ROI, K_normal), axis=1)
 
         m, n = np.shape(K_ROI)
@@ -247,6 +246,12 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
         # ln(xn) = x(n-1) + inv(term1+term2)@(term3 + term4)
         # where x(n-1) is the previous iteration of xn until convergence
         print("Status: Iterating to calculate ln(xn)")
+
+        xnmean = np.concatenate(
+            (np.exp(lnxn[:-num_normal_elems]), lnxn[-num_normal_elems:]),
+            axis=0,
+        )   
+    
         while xn_iteration_pct_diff >= convergence_threshold:
 
             # we need to transform lnxn to xn to calculate K_prime
@@ -256,7 +261,7 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
             )
             # K_prime is the updated jacobian using the new xn from the previous iteration
             K_prime = np.concatenate(
-                (K_ROI * xn[:-num_normal_elems].T, K_normal), axis=1
+                (prior_scale * K_ROI * xn[:-num_normal_elems].T, K_normal), axis=1
             )
 
             # commonly used term for term1 and term3
@@ -267,7 +272,7 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
             term2 = (1 + kappa) * invlnsa_constraint
             inv_term = np.linalg.inv(term1 + term2)
 
-            term3 = gamma_K_prime_transpose_Soinv @ (y_ybkg_diff - K_full @ xn)
+            term3 = gamma_K_prime_transpose_Soinv @ (y_ybkg_diff - K_full @ xnmean)
             term4 = invlnsa_constraint @ (lnxn - lnxa)
 
             # put it all together to calculate lnxn_update
@@ -284,28 +289,29 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
 
             lnxn = lnxn_update
 
-        print("Status: Done Iterating")
-        xn = np.concatenate(
-            (np.exp(lnxn[:-num_normal_elems]), lnxn[-num_normal_elems:]), axis=0
-        )
+            # Calculate averaging kernel and degrees of freedom for signal
+            K_primeT_so = gamma * np.transpose(K_prime) @ Soinv
+            # posterior error covariance matrix (uses unweighted Sa)
+            lns = np.linalg.inv(K_primeT_so @ K_prime + invlnsa)
 
-        # Calculate averaging kernel and degrees of freedom for signal
-        K_primeT_so = gamma * np.transpose(K_prime) @ Soinv
-        # posterior error covariance matrix (uses unweighted Sa)
-        lns = np.linalg.inv(K_primeT_so @ K_prime + invlnsa)
+            # Calculate posterior mean xhat
+            dlns = np.diag(lns[:-num_normal_elems, :-num_normal_elems])
+            xn = np.concatenate(
+                (np.exp(lnxn[:-num_normal_elems]), lnxn[-num_normal_elems:]), axis=0
+            )
+            xnmean = np.concatenate(
+                (
+                    xn[:-num_normal_elems]
+                    * np.expand_dims(np.exp(dlns * (0.5)) * prior_scale, axis=1),
+                    xn[-num_normal_elems:],
+                )
+            )
+
+        print("Status: Done Iterating")
+
         # Averaging kernel (uses unweighted Sa)
         G = lns @ K_primeT_so
         ak = G @ K_prime
-
-        # Calculate posterior mean xhat
-        dlns = np.diag(lns[:-num_normal_elems, :-num_normal_elems])
-        xnmean = np.concatenate(
-            (
-                xn[:-num_normal_elems]
-                * np.expand_dims(np.exp(dlns * (0.5)) * prior_scale, axis=1),
-                xn[-num_normal_elems:],
-            )
-        )
 
         # Calculate Ja diagnostic only for domain of interest (ignoring buffer and BC elements)
         # Ja diagnostic is useful for determining regurlarization parameter (gamma)

--- a/src/inversion_scripts/lognormal_invert.py
+++ b/src/inversion_scripts/lognormal_invert.py
@@ -248,7 +248,7 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
         print("Status: Iterating to calculate ln(xn)")
 
         xnmean = np.concatenate(
-            (np.exp(lnxn[:-num_normal_elems]), lnxn[-num_normal_elems:]),
+            (np.exp(lnxn[:-num_normal_elems]) * prior_scale, lnxn[-num_normal_elems:]),
             axis=0,
         )   
     
@@ -261,7 +261,7 @@ def lognormal_invert(config, state_vector_filepath, jacobian_sf):
             )
             # K_prime is the updated jacobian using the new xn from the previous iteration
             K_prime = np.concatenate(
-                (prior_scale * K_ROI * xn[:-num_normal_elems].T, K_normal), axis=1
+                (K_ROI * xnmean[:-num_normal_elems].T, K_normal), axis=1
             )
 
             # commonly used term for term1 and term3


### PR DESCRIPTION
### Name and Institution (Required)

Name: Xiaolin Wang
Institution: Harvard

### Describe the update
The lognormal inversion optimizes x' = ln(x), where exp(x') is the median of x. The state vector and the prior term J_A are therefore expressed in terms of the median. However, in the observation term, (y - F(x')) is the mismatch between observed and simulated concentrations, and the simulation is driven by the mean emissions. It is the mean of the emissions, not the median, that we require to be consistent with the observations.

IMI currently evaluates F(x') = K·x_n with x_n the median of x, which biases simulated concentrations low and drives the posterior emissions high. The updated code now evaluates the observation term as y - K·x_mean, with the mean emissions updated at each iteration.
